### PR TITLE
feat: retro eval pipeline for Dataverse transcripts

### DIFF
--- a/retro_eval.py
+++ b/retro_eval.py
@@ -1,0 +1,452 @@
+"""Retrospective eval runner for Copilot Studio conversation transcripts.
+
+Fetches historical transcripts from Dataverse and runs deterministic Tier 1
+eval metrics without re-invoking the agent. Also suggests new test cases
+from discovered utterance patterns.
+
+CLI usage:
+    uv run python retro_eval.py
+    uv run python retro_eval.py --since 2025-01-01 --top 200 --suggest-only
+"""
+
+import asyncio
+import json
+import os
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+
+from loguru import logger
+
+from dataverse_client import DataverseClient
+from eval_engine import (
+    _evaluate_exact_match,
+    _evaluate_keyword_match,
+    _evaluate_topic_routing,
+)
+
+
+@dataclass
+class RetroTestCase:
+    """A test case extracted from a historical transcript."""
+
+    transcript_id: str
+    conversation: list[dict]  # [{"role": "user"|"assistant", "content": str}]
+    turns: list[dict]  # user-only turns
+    intent_recognition: list[dict]  # from parse_transcript
+    session_outcome: str  # Resolved / Escalated / Abandoned
+    dialog_redirects: list[str]
+    csat: float | None
+    created_at: str | None
+
+
+@dataclass
+class RetroEvalResult:
+    """Result of running Tier 1 metrics on a single retro test case."""
+
+    transcript_id: str
+    metric_results: dict[str, dict]  # metric_name -> {score, reason, passed}
+    session_outcome: str
+    csat: float | None
+    conversation_length: int
+
+
+@dataclass
+class DatasetSuggestion:
+    """A suggested test case for dataset improvement."""
+
+    utterance: str  # The user's first message
+    follow_up_turns: list[str]  # Additional user messages (for multi-turn)
+    inferred_topic: str  # From intent recognition
+    session_outcome: str
+    source_transcript_id: str
+    is_multi_turn: bool
+
+
+def extract_test_case_from_transcript(
+    transcript: dict,
+    client: DataverseClient,
+) -> RetroTestCase | None:
+    """Convert a raw Dataverse transcript record into a RetroTestCase.
+
+    Args:
+        transcript: Raw record from Dataverse conversationtranscripts table.
+        client: DataverseClient instance for parsing.
+
+    Returns:
+        RetroTestCase or None if the transcript has no usable conversation.
+    """
+    content = transcript.get("content", "")
+    transcript_id = transcript.get("conversationtranscriptid", "")
+
+    conversation = client.extract_conversation(content)
+    if not conversation:
+        logger.debug(f"Transcript {transcript_id}: no message activities found")
+        return None
+
+    parsed = client.parse_transcript(content)
+    turns = [t for t in conversation if t["role"] == "user"]
+
+    if not turns:
+        return None
+
+    return RetroTestCase(
+        transcript_id=transcript_id,
+        conversation=[{"role": t["role"], "content": t["content"]} for t in conversation],
+        turns=[{"role": "user", "content": t["content"]} for t in turns],
+        intent_recognition=parsed["intent_recognition"],
+        session_outcome=parsed["session_info"]["outcome"],
+        dialog_redirects=parsed["dialog_redirects"],
+        csat=parsed["csat"],
+        created_at=transcript.get("createdon"),
+    )
+
+
+def run_tier1_metrics(
+    test_case: RetroTestCase,
+    expected_topic: str = "",
+    keywords_any: list[str] | None = None,
+    keywords_all: list[str] | None = None,
+    expected_output: str = "",
+) -> dict[str, dict]:
+    """Run applicable Tier 1 deterministic metrics on a retro test case.
+
+    Metrics that run automatically (no configuration needed):
+    - topic_routing: if intent_recognition data is present
+
+    Metrics that run when configuration is provided:
+    - exact_match: if expected_output is set
+    - keyword_match_any: if keywords_any is set
+    - keyword_match_all: if keywords_all is set
+
+    Args:
+        test_case: The retro test case to evaluate.
+        expected_topic: Topic name expected in intent recognition.
+        keywords_any: Keywords where at least one must appear in the last response.
+        keywords_all: Keywords that must all appear in the last response.
+        expected_output: Exact expected text for the last assistant response.
+
+    Returns:
+        Dict mapping metric_name -> {score, reason, passed}
+    """
+    results: dict[str, dict] = {}
+
+    # Get last assistant response for text-based metrics
+    actual_output = ""
+    for msg in reversed(test_case.conversation):
+        if msg["role"] == "assistant":
+            actual_output = msg["content"]
+            break
+
+    # topic_routing — uses intent recognition data extracted from transcript
+    if expected_topic or test_case.intent_recognition:
+        # Build synthetic activities from parsed intent recognition
+        activities = []
+        for intent in test_case.intent_recognition:
+            topic = intent.get("topic", "")
+            if topic:
+                activities.append(
+                    {
+                        "name": "DynamicPlanStepTriggered",
+                        "value": {"taskDialogId": topic},
+                    }
+                )
+        if activities or expected_topic:
+            results["topic_routing"] = _evaluate_topic_routing(activities, expected_topic)
+
+    if expected_output:
+        results["exact_match"] = _evaluate_exact_match(actual_output, expected_output)
+
+    if keywords_any:
+        results["keyword_match_any"] = _evaluate_keyword_match(actual_output, keywords_any, "any")
+
+    if keywords_all:
+        results["keyword_match_all"] = _evaluate_keyword_match(actual_output, keywords_all, "all")
+
+    return results
+
+
+def suggest_dataset_cases(
+    test_cases: list[RetroTestCase],
+    existing_utterances: set[str] | None = None,
+    min_confidence: float = 0.5,
+) -> list[DatasetSuggestion]:
+    """Identify utterances from transcripts as dataset improvement suggestions.
+
+    Filters out:
+    - Transcripts with no clear intent (confidence below min_confidence)
+    - Utterances already present in the existing dataset
+
+    Multi-turn conversations (>1 user turn) are flagged as multi_turn suggestions.
+
+    Args:
+        test_cases: Extracted test cases from transcripts.
+        existing_utterances: Normalised utterances already in datasets (lowercased).
+        min_confidence: Minimum intent confidence to include a suggestion.
+
+    Returns:
+        List of DatasetSuggestion instances.
+    """
+    seen_utterances: set[str] = set(existing_utterances or [])
+    suggestions: list[DatasetSuggestion] = []
+
+    for tc in test_cases:
+        if not tc.turns:
+            continue
+
+        first_utterance = tc.turns[0]["content"]
+        normalised = first_utterance.strip().lower()
+
+        if normalised in seen_utterances:
+            continue
+
+        # Pick best inferred topic
+        inferred_topic = ""
+        if tc.intent_recognition:
+            best = max(tc.intent_recognition, key=lambda x: x.get("score", 0.0))
+            if best.get("score", 0.0) >= min_confidence:
+                inferred_topic = best.get("topic", "")
+
+        follow_ups = [t["content"] for t in tc.turns[1:]]
+
+        suggestions.append(
+            DatasetSuggestion(
+                utterance=first_utterance,
+                follow_up_turns=follow_ups,
+                inferred_topic=inferred_topic,
+                session_outcome=tc.session_outcome,
+                source_transcript_id=tc.transcript_id,
+                is_multi_turn=len(tc.turns) > 1,
+            )
+        )
+        seen_utterances.add(normalised)
+
+    logger.info(
+        f"Generated {len(suggestions)} dataset suggestion(s) from {len(test_cases)} transcript(s)"
+    )
+    return suggestions
+
+
+async def run_retro_evals(
+    bot_guid: str,
+    client: DataverseClient,
+    since: datetime,
+    top: int = 100,
+    expected_topic: str = "",
+    keywords_any: list[str] | None = None,
+    keywords_all: list[str] | None = None,
+) -> list[RetroEvalResult]:
+    """Fetch transcripts and run Tier 1 metrics on each.
+
+    Args:
+        bot_guid: The bot's GUID to fetch transcripts for.
+        client: Authenticated DataverseClient.
+        since: Fetch transcripts created after this datetime.
+        top: Max number of transcripts to process.
+        expected_topic: Optional topic name for topic_routing metric.
+        keywords_any: Optional keywords for keyword_match_any metric.
+        keywords_all: Optional keywords for keyword_match_all metric.
+
+    Returns:
+        List of RetroEvalResult for each processable transcript.
+    """
+    transcripts = await client.fetch_transcripts(bot_guid, since, top=top)
+    logger.info(f"Processing {len(transcripts)} transcript(s)")
+
+    eval_results: list[RetroEvalResult] = []
+    skipped = 0
+
+    for t in transcripts:
+        test_case = extract_test_case_from_transcript(t, client)
+        if test_case is None:
+            skipped += 1
+            continue
+
+        metric_results = run_tier1_metrics(
+            test_case,
+            expected_topic=expected_topic,
+            keywords_any=keywords_any,
+            keywords_all=keywords_all,
+        )
+
+        eval_results.append(
+            RetroEvalResult(
+                transcript_id=test_case.transcript_id,
+                metric_results=metric_results,
+                session_outcome=test_case.session_outcome,
+                csat=test_case.csat,
+                conversation_length=len(test_case.conversation),
+            )
+        )
+
+    logger.info(
+        f"Retro eval complete: {len(eval_results)} evaluated, {skipped} skipped (no messages)"
+    )
+    return eval_results
+
+
+def _print_summary(eval_results: list[RetroEvalResult]) -> None:
+    """Print a human-readable summary of retro eval results."""
+    if not eval_results:
+        print("No results.")
+        return
+
+    total = len(eval_results)
+    outcome_counts: dict[str, int] = {}
+    for r in eval_results:
+        outcome_counts[r.session_outcome or "Unknown"] = (
+            outcome_counts.get(r.session_outcome or "Unknown", 0) + 1
+        )
+
+    print(f"\n=== Retro Eval Summary ({total} transcripts) ===")
+    print("\nSession outcomes:")
+    for outcome, count in sorted(outcome_counts.items()):
+        print(f"  {outcome}: {count}")
+
+    # Per-metric pass rates
+    metric_pass: dict[str, list[bool]] = {}
+    for r in eval_results:
+        for metric, result in r.metric_results.items():
+            metric_pass.setdefault(metric, []).append(result["passed"])
+
+    if metric_pass:
+        print("\nMetric pass rates:")
+        for metric, passes in sorted(metric_pass.items()):
+            rate = sum(passes) / len(passes) * 100
+            print(f"  {metric}: {rate:.1f}% ({sum(passes)}/{len(passes)})")
+
+    csat_scores = [r.csat for r in eval_results if r.csat is not None]
+    if csat_scores:
+        avg_csat = sum(csat_scores) / len(csat_scores)
+        print(f"\nAvg CSAT: {avg_csat:.2f} (n={len(csat_scores)})")
+
+
+async def _cli_main() -> None:
+    """CLI entry point for running retro evals."""
+    import argparse
+
+    from dotenv import load_dotenv
+
+    load_dotenv()
+
+    parser = argparse.ArgumentParser(description="Run retrospective evals on Dataverse transcripts")
+    parser.add_argument(
+        "--since",
+        default="2025-01-01",
+        help="Fetch transcripts created after this date (YYYY-MM-DD). Default: 2025-01-01",
+    )
+    parser.add_argument(
+        "--top",
+        type=int,
+        default=100,
+        help="Max number of transcripts to fetch. Default: 100",
+    )
+    parser.add_argument(
+        "--suggest-only",
+        action="store_true",
+        help="Only print dataset suggestions, skip eval metrics",
+    )
+    parser.add_argument(
+        "--expected-topic",
+        default="",
+        help="Expected topic for topic_routing metric",
+    )
+    parser.add_argument(
+        "--output",
+        choices=["summary", "json"],
+        default="summary",
+        help="Output format. Default: summary",
+    )
+    args = parser.parse_args()
+
+    bot_guid = os.environ.get("COPILOT_AGENT_IDENTIFIER", "")
+    if not bot_guid:
+        logger.error("COPILOT_AGENT_IDENTIFIER not set")
+        return
+
+    since = datetime.fromisoformat(args.since).replace(tzinfo=timezone.utc)
+
+    dv_client = DataverseClient(
+        org_url=os.environ["DATAVERSE_ORG_URL"],
+        tenant_id=os.environ["AZURE_AD_TENANT_ID"],
+        client_id=os.environ["AZURE_AD_CLIENT_ID"],
+        client_secret=os.environ["AZURE_AD_CLIENT_SECRET"],
+    )
+
+    try:
+        transcripts = await dv_client.fetch_transcripts(bot_guid, since, top=args.top)
+    except Exception as e:
+        logger.error(f"Failed to fetch transcripts: {e}")
+        return
+
+    test_cases = []
+    for t in transcripts:
+        tc = extract_test_case_from_transcript(t, dv_client)
+        if tc:
+            test_cases.append(tc)
+
+    if args.suggest_only:
+        suggestions = suggest_dataset_cases(test_cases)
+        if args.output == "json":
+            print(
+                json.dumps(
+                    [
+                        {
+                            "utterance": s.utterance,
+                            "follow_up_turns": s.follow_up_turns,
+                            "inferred_topic": s.inferred_topic,
+                            "session_outcome": s.session_outcome,
+                            "source_transcript_id": s.source_transcript_id,
+                            "is_multi_turn": s.is_multi_turn,
+                        }
+                        for s in suggestions
+                    ],
+                    indent=2,
+                )
+            )
+        else:
+            print(f"\n=== Dataset Suggestions ({len(suggestions)}) ===")
+            for s in suggestions:
+                tag = "[multi-turn]" if s.is_multi_turn else "[single-turn]"
+                print(f"\n{tag} {s.utterance[:80]}")
+                if s.inferred_topic:
+                    print(f"  Topic: {s.inferred_topic}")
+                print(f"  Outcome: {s.session_outcome or 'Unknown'}")
+                if s.follow_up_turns:
+                    print(f"  Follow-ups: {len(s.follow_up_turns)} more turns")
+        return
+
+    eval_results = []
+    for tc in test_cases:
+        metric_results = run_tier1_metrics(tc, expected_topic=args.expected_topic)
+        eval_results.append(
+            RetroEvalResult(
+                transcript_id=tc.transcript_id,
+                metric_results=metric_results,
+                session_outcome=tc.session_outcome,
+                csat=tc.csat,
+                conversation_length=len(tc.conversation),
+            )
+        )
+
+    if args.output == "json":
+        print(
+            json.dumps(
+                [
+                    {
+                        "transcript_id": r.transcript_id,
+                        "metric_results": r.metric_results,
+                        "session_outcome": r.session_outcome,
+                        "csat": r.csat,
+                        "conversation_length": r.conversation_length,
+                    }
+                    for r in eval_results
+                ],
+                indent=2,
+            )
+        )
+    else:
+        _print_summary(eval_results)
+
+
+if __name__ == "__main__":
+    asyncio.run(_cli_main())

--- a/tests/test_retro_eval.py
+++ b/tests/test_retro_eval.py
@@ -1,0 +1,500 @@
+"""Unit tests for retro_eval module."""
+
+import json
+
+import pytest
+
+
+def _make_client():
+    from dataverse_client import DataverseClient
+
+    return DataverseClient("https://org.crm.dynamics.com", "tenant", "client", "secret")
+
+
+# --- extract_conversation tests ---
+
+
+def test_extract_conversation_basic():
+    from dataverse_client import DataverseClient
+
+    client = _make_client()
+    content = json.dumps([
+        {
+            "type": "message",
+            "from": {"id": "user-1", "role": "user"},
+            "text": "Hello, I need help",
+            "timestamp": "2024-01-15T10:00:00Z",
+        },
+        {
+            "type": "message",
+            "from": {"id": "bot-1", "role": "bot"},
+            "text": "Sure, I can help you.",
+            "timestamp": "2024-01-15T10:00:05Z",
+        },
+    ])
+
+    turns = client.extract_conversation(content)
+
+    assert len(turns) == 2
+    assert turns[0]["role"] == "user"
+    assert turns[0]["content"] == "Hello, I need help"
+    assert turns[1]["role"] == "assistant"
+    assert turns[1]["content"] == "Sure, I can help you."
+
+
+def test_extract_conversation_skips_non_message_activities():
+    client = _make_client()
+    content = json.dumps([
+        {
+            "type": "event",
+            "valueType": "IntentRecognition",
+            "value": {"topicName": "LeaveBalance", "confidence": 0.9},
+        },
+        {
+            "type": "message",
+            "from": {"id": "user-1", "role": "user"},
+            "text": "What is my leave balance?",
+        },
+        {
+            "type": "trace",
+            "label": "Recognizer result",
+        },
+    ])
+
+    turns = client.extract_conversation(content)
+
+    assert len(turns) == 1
+    assert turns[0]["role"] == "user"
+    assert turns[0]["content"] == "What is my leave balance?"
+
+
+def test_extract_conversation_skips_empty_text():
+    client = _make_client()
+    content = json.dumps([
+        {
+            "type": "message",
+            "from": {"id": "user-1", "role": "user"},
+            "text": "   ",  # whitespace only
+        },
+        {
+            "type": "message",
+            "from": {"id": "user-1", "role": "user"},
+            "text": "Real message",
+        },
+    ])
+
+    turns = client.extract_conversation(content)
+
+    assert len(turns) == 1
+    assert turns[0]["content"] == "Real message"
+
+
+def test_extract_conversation_empty_content():
+    client = _make_client()
+    assert client.extract_conversation("") == []
+
+
+def test_extract_conversation_invalid_json():
+    client = _make_client()
+    assert client.extract_conversation("{not json") == []
+
+
+def test_extract_conversation_skill_role():
+    """Role 'skill' should map to assistant."""
+    client = _make_client()
+    content = json.dumps([
+        {
+            "type": "message",
+            "from": {"role": "skill"},
+            "text": "Skill response",
+        },
+    ])
+
+    turns = client.extract_conversation(content)
+    assert turns[0]["role"] == "assistant"
+
+
+def test_extract_conversation_fallback_role_from_id():
+    """When role is missing, fall back to checking from.id."""
+    client = _make_client()
+    content = json.dumps([
+        {
+            "type": "message",
+            "from": {"id": "bot-abc"},
+            "text": "Bot response without role field",
+        },
+    ])
+
+    turns = client.extract_conversation(content)
+    assert turns[0]["role"] == "assistant"
+
+
+# --- extract_test_case_from_transcript tests ---
+
+
+def _make_transcript(content: list[dict], transcript_id: str = "tid-001") -> dict:
+    return {
+        "conversationtranscriptid": transcript_id,
+        "content": json.dumps(content),
+        "createdon": "2024-01-15T10:00:00Z",
+    }
+
+
+def test_extract_test_case_basic():
+    from retro_eval import extract_test_case_from_transcript
+
+    client = _make_client()
+    content = [
+        {
+            "type": "message",
+            "from": {"role": "user"},
+            "text": "I need leave",
+        },
+        {
+            "type": "message",
+            "from": {"role": "bot"},
+            "text": "You have 12 days remaining.",
+        },
+        {
+            "valueType": "SessionInfo",
+            "value": {"outcome": "Resolved"},
+        },
+        {
+            "valueType": "IntentRecognition",
+            "value": {"topicName": "LeaveBalance", "confidence": 0.95},
+        },
+    ]
+    transcript = _make_transcript(content)
+    tc = extract_test_case_from_transcript(transcript, client)
+
+    assert tc is not None
+    assert tc.transcript_id == "tid-001"
+    assert len(tc.conversation) == 2
+    assert tc.turns[0]["content"] == "I need leave"
+    assert tc.session_outcome == "Resolved"
+    assert tc.intent_recognition[0]["topic"] == "LeaveBalance"
+
+
+def test_extract_test_case_no_messages_returns_none():
+    from retro_eval import extract_test_case_from_transcript
+
+    client = _make_client()
+    content = [
+        {"valueType": "SessionInfo", "value": {"outcome": "Abandoned"}},
+    ]
+    transcript = _make_transcript(content)
+    result = extract_test_case_from_transcript(transcript, client)
+    assert result is None
+
+
+def test_extract_test_case_empty_content_returns_none():
+    from retro_eval import extract_test_case_from_transcript
+
+    client = _make_client()
+    transcript = {"conversationtranscriptid": "tid-002", "content": "", "createdon": None}
+    result = extract_test_case_from_transcript(transcript, client)
+    assert result is None
+
+
+# --- run_tier1_metrics tests ---
+
+
+def _make_test_case(
+    conversation: list[dict] | None = None,
+    intents: list[dict] | None = None,
+    outcome: str = "Resolved",
+) -> "RetroTestCase":
+    from retro_eval import RetroTestCase
+
+    conv = conversation or [
+        {"role": "user", "content": "Hello"},
+        {"role": "assistant", "content": "Hi there!"},
+    ]
+    turns = [t for t in conv if t["role"] == "user"]
+    return RetroTestCase(
+        transcript_id="tid-test",
+        conversation=conv,
+        turns=turns,
+        intent_recognition=intents or [],
+        session_outcome=outcome,
+        dialog_redirects=[],
+        csat=None,
+        created_at=None,
+    )
+
+
+def test_run_tier1_metrics_topic_routing_match():
+    from retro_eval import run_tier1_metrics
+
+    tc = _make_test_case(intents=[{"topic": "rrs_bot.topic.Greeting", "score": 0.9}])
+    results = run_tier1_metrics(tc, expected_topic="Greeting")
+
+    assert "topic_routing" in results
+    assert results["topic_routing"]["passed"] is True
+
+
+def test_run_tier1_metrics_topic_routing_mismatch():
+    from retro_eval import run_tier1_metrics
+
+    tc = _make_test_case(intents=[{"topic": "rrs_bot.topic.Greeting", "score": 0.9}])
+    results = run_tier1_metrics(tc, expected_topic="ITSupport")
+
+    assert "topic_routing" in results
+    assert results["topic_routing"]["passed"] is False
+
+
+def test_run_tier1_metrics_exact_match():
+    from retro_eval import run_tier1_metrics
+
+    tc = _make_test_case(
+        conversation=[
+            {"role": "user", "content": "Say hi"},
+            {"role": "assistant", "content": "Hi there!"},
+        ]
+    )
+    results = run_tier1_metrics(tc, expected_output="Hi there!")
+
+    assert "exact_match" in results
+    assert results["exact_match"]["passed"] is True
+
+
+def test_run_tier1_metrics_keyword_any():
+    from retro_eval import run_tier1_metrics
+
+    tc = _make_test_case(
+        conversation=[
+            {"role": "user", "content": "Check leave"},
+            {"role": "assistant", "content": "You have 5 days remaining."},
+        ]
+    )
+    results = run_tier1_metrics(tc, keywords_any=["days remaining", "vacation"])
+
+    assert "keyword_match_any" in results
+    assert results["keyword_match_any"]["passed"] is True
+
+
+def test_run_tier1_metrics_keyword_all_partial():
+    from retro_eval import run_tier1_metrics
+
+    tc = _make_test_case(
+        conversation=[
+            {"role": "user", "content": "Get policy"},
+            {"role": "assistant", "content": "Policy ID: 123"},
+        ]
+    )
+    results = run_tier1_metrics(tc, keywords_all=["Policy ID:", "expires"])
+
+    assert "keyword_match_all" in results
+    assert results["keyword_match_all"]["passed"] is False
+
+
+def test_run_tier1_metrics_no_config_no_intents():
+    """When no topic/keywords/expected_output and no intents, no metrics run."""
+    from retro_eval import run_tier1_metrics
+
+    tc = _make_test_case(intents=[])
+    results = run_tier1_metrics(tc)
+
+    assert results == {}
+
+
+# --- suggest_dataset_cases tests ---
+
+
+def test_suggest_dataset_cases_basic():
+    from retro_eval import suggest_dataset_cases
+
+    tc1 = _make_test_case(
+        conversation=[
+            {"role": "user", "content": "What is my leave balance?"},
+            {"role": "assistant", "content": "You have 10 days."},
+        ],
+        intents=[{"topic": "LeaveBalance", "score": 0.9}],
+        outcome="Resolved",
+    )
+    tc1.transcript_id = "tid-001"
+
+    suggestions = suggest_dataset_cases([tc1])
+
+    assert len(suggestions) == 1
+    assert suggestions[0].utterance == "What is my leave balance?"
+    assert suggestions[0].inferred_topic == "LeaveBalance"
+    assert suggestions[0].is_multi_turn is False
+
+
+def test_suggest_dataset_cases_deduplication():
+    from retro_eval import suggest_dataset_cases
+
+    tc1 = _make_test_case(
+        conversation=[
+            {"role": "user", "content": "Check my leave"},
+            {"role": "assistant", "content": "10 days."},
+        ]
+    )
+    tc1.transcript_id = "tid-001"
+
+    tc2 = _make_test_case(
+        conversation=[
+            {"role": "user", "content": "Check my leave"},  # same utterance
+            {"role": "assistant", "content": "12 days."},
+        ]
+    )
+    tc2.transcript_id = "tid-002"
+
+    suggestions = suggest_dataset_cases([tc1, tc2])
+    assert len(suggestions) == 1
+
+
+def test_suggest_dataset_cases_existing_utterances_filtered():
+    from retro_eval import suggest_dataset_cases
+
+    tc = _make_test_case(
+        conversation=[
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": "Hi!"},
+        ]
+    )
+    tc.transcript_id = "tid-001"
+
+    suggestions = suggest_dataset_cases([tc], existing_utterances={"hello"})
+    assert len(suggestions) == 0
+
+
+def test_suggest_dataset_cases_multi_turn():
+    from retro_eval import suggest_dataset_cases, RetroTestCase
+
+    tc = RetroTestCase(
+        transcript_id="tid-mt",
+        conversation=[
+            {"role": "user", "content": "I need IT support"},
+            {"role": "assistant", "content": "Sure, what's the issue?"},
+            {"role": "user", "content": "My laptop won't start"},
+            {"role": "assistant", "content": "Let me raise a ticket."},
+        ],
+        turns=[
+            {"role": "user", "content": "I need IT support"},
+            {"role": "user", "content": "My laptop won't start"},
+        ],
+        intent_recognition=[{"topic": "ITSupport", "score": 0.88}],
+        session_outcome="Escalated",
+        dialog_redirects=[],
+        csat=None,
+        created_at=None,
+    )
+
+    suggestions = suggest_dataset_cases([tc])
+
+    assert len(suggestions) == 1
+    assert suggestions[0].is_multi_turn is True
+    assert len(suggestions[0].follow_up_turns) == 1
+    assert suggestions[0].follow_up_turns[0] == "My laptop won't start"
+
+
+def test_suggest_dataset_cases_low_confidence_no_topic():
+    from retro_eval import suggest_dataset_cases
+
+    tc = _make_test_case(
+        conversation=[
+            {"role": "user", "content": "Random message"},
+            {"role": "assistant", "content": "I see."},
+        ],
+        intents=[{"topic": "Something", "score": 0.2}],  # below default 0.5
+    )
+    tc.transcript_id = "tid-low"
+
+    suggestions = suggest_dataset_cases([tc], min_confidence=0.5)
+
+    assert len(suggestions) == 1
+    # Topic not inferred due to low confidence
+    assert suggestions[0].inferred_topic == ""
+
+
+# --- Integration-style test: full pipeline ---
+
+
+def test_full_retro_pipeline():
+    from retro_eval import extract_test_case_from_transcript, run_tier1_metrics, suggest_dataset_cases
+
+    client = _make_client()
+
+    transcripts = [
+        _make_transcript(
+            [
+                {
+                    "type": "message",
+                    "from": {"role": "user"},
+                    "text": "How many vacation days do I have?",
+                },
+                {
+                    "type": "message",
+                    "from": {"role": "bot"},
+                    "text": "You have 15 vacation days remaining.",
+                },
+                {
+                    "valueType": "IntentRecognition",
+                    "value": {"topicName": "VacationBalance", "confidence": 0.92},
+                },
+                {
+                    "valueType": "SessionInfo",
+                    "value": {"outcome": "Resolved"},
+                },
+            ],
+            transcript_id="tid-full-001",
+        ),
+        _make_transcript(
+            [
+                {
+                    "type": "message",
+                    "from": {"role": "user"},
+                    "text": "I want to report an IT issue",
+                },
+                {
+                    "type": "message",
+                    "from": {"role": "bot"},
+                    "text": "Please describe your IT problem.",
+                },
+                {
+                    "type": "message",
+                    "from": {"role": "user"},
+                    "text": "My VPN keeps disconnecting",
+                },
+                {
+                    "type": "message",
+                    "from": {"role": "bot"},
+                    "text": "I've raised a ticket for you.",
+                },
+                {
+                    "valueType": "IntentRecognition",
+                    "value": {"topicName": "ITSupport", "confidence": 0.85},
+                },
+                {
+                    "valueType": "SessionInfo",
+                    "value": {"outcome": "Escalated"},
+                },
+            ],
+            transcript_id="tid-full-002",
+        ),
+    ]
+
+    test_cases = []
+    for t in transcripts:
+        tc = extract_test_case_from_transcript(t, client)
+        if tc:
+            test_cases.append(tc)
+
+    assert len(test_cases) == 2
+
+    # Run metrics
+    results_0 = run_tier1_metrics(
+        test_cases[0],
+        keywords_any=["vacation days", "days remaining"],
+    )
+    assert results_0["keyword_match_any"]["passed"] is True
+
+    # Dataset suggestions
+    suggestions = suggest_dataset_cases(test_cases)
+    assert len(suggestions) == 2
+
+    multi_turn = [s for s in suggestions if s.is_multi_turn]
+    assert len(multi_turn) == 1
+    assert "IT" in multi_turn[0].utterance or "IT" in multi_turn[0].inferred_topic


### PR DESCRIPTION
## Summary

Closes #2

Implements retrospective eval capability: fetch historical conversation transcripts from Dataverse and run deterministic Tier 1 metrics without re-invoking the agent. Also identifies utterance patterns as dataset improvement suggestions.

### Changes

**`dataverse_client.py`**
- Added `DataverseClient.extract_conversation()` — parses Bot Framework `message` activities from transcript content into `[{role, content, timestamp}]` turns (handles `user`/`bot`/`skill` roles and fallback via `from.id`)

**`retro_eval.py`** (new)
- `RetroTestCase` / `RetroEvalResult` / `DatasetSuggestion` dataclasses
- `extract_test_case_from_transcript()` — converts a raw Dataverse record into a test case
- `run_tier1_metrics()` — runs `exact_match`, `keyword_match_any/all`, `topic_routing` on historical data (no LLM cost)
- `run_retro_evals()` — async pipeline: fetch → extract → evaluate
- `suggest_dataset_cases()` — deduplicates utterances, flags multi-turn conversations, filters by intent confidence, returns `DatasetSuggestion` list
- CLI: `uv run python retro_eval.py [--since DATE] [--top N] [--suggest-only] [--output json|summary]`

**`tests/test_retro_eval.py`** (new)
- 22 unit tests covering all new functions

## Test plan

- [x] All 84 tests pass (`uv run pytest`)
- [x] `extract_conversation` handles user/bot/skill roles, empty text, non-message activities, invalid JSON
- [x] `extract_test_case_from_transcript` returns `None` for transcripts with no messages
- [x] `run_tier1_metrics` correctly dispatches to topic_routing, exact_match, keyword_match
- [x] `suggest_dataset_cases` deduplicates, filters existing utterances, flags multi-turn, respects confidence threshold

🤖 Generated with [Claude Code](https://claude.com/claude-code)