### PR TITLE
feat: add Transcript Extract page with retro eval pipeline

### DIFF
--- a/d2e_client.py
+++ b/d2e_client.py
@@ -5,7 +5,9 @@ Adapted from Evals-plural/copilot_bridge.py patterns.
 """
 
 import asyncio
+import json
 import os
+import re
 
 import aiohttp
 from loguru import logger
@@ -17,22 +19,114 @@ from microsoft_agents.copilotstudio.client.power_platform_environment import (
 
 from auth import acquire_token
 
+_UUID_RE = re.compile(
+    r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+    re.IGNORECASE,
+)
+
+# ── File sink: all DEBUG+ logs from this module go to logs/d2e.log ──────────
+logger.add(
+    "logs/d2e.log",
+    level="DEBUG",
+    format="{time:DD-MM-YYYY HH:mm:ss.SSS} | {level:<8} | {message}",
+    rotation="10 MB",
+    retention=3,
+    encoding="utf-8",
+)
+
+
+# ── aiohttp trace callbacks ──────────────────────────────────────────────────
+
+async def _trace_request_start(
+    session: aiohttp.ClientSession,
+    ctx: aiohttp.TraceRequestStartParams,
+    params: aiohttp.TraceRequestStartParams,
+) -> None:
+    headers = dict(params.headers)
+    if "Authorization" in headers:
+        auth = headers["Authorization"]
+        headers["Authorization"] = auth[:27] + "...<masked>"
+    logger.debug(
+        f">>> {params.method} {params.url}\n"
+        f"    Headers: {json.dumps(headers, indent=6)}"
+    )
+
+
+async def _trace_request_chunk_sent(
+    session: aiohttp.ClientSession,
+    ctx: aiohttp.TraceRequestChunkSentParams,
+    params: aiohttp.TraceRequestChunkSentParams,
+) -> None:
+    if params.chunk:
+        try:
+            body = json.loads(params.chunk)
+            logger.debug(f"    Body: {json.dumps(body, indent=6)}")
+        except Exception:
+            logger.debug(f"    Body (raw): {params.chunk[:500]}")
+
+
+async def _trace_request_end(
+    session: aiohttp.ClientSession,
+    ctx: aiohttp.TraceRequestEndParams,
+    params: aiohttp.TraceRequestEndParams,
+) -> None:
+    logger.debug(
+        f"<<< {params.response.status} {params.response.reason}\n"
+        f"    Headers: {json.dumps(dict(params.response.headers), indent=6)}"
+    )
+
+
+async def _trace_request_exception(
+    session: aiohttp.ClientSession,
+    ctx: aiohttp.TraceRequestExceptionParams,
+    params: aiohttp.TraceRequestExceptionParams,
+) -> None:
+    logger.error(f"!!! Request exception: {params.exception}")
+
+
+def _make_trace_config() -> aiohttp.TraceConfig:
+    tc = aiohttp.TraceConfig()
+    tc.on_request_start.append(_trace_request_start)
+    tc.on_request_chunk_sent.append(_trace_request_chunk_sent)
+    tc.on_request_end.append(_trace_request_end)
+    tc.on_request_exception.append(_trace_request_exception)
+    return tc
+
 
 def _get_settings() -> ConnectionSettings:
     """Build ConnectionSettings from env vars."""
-    return ConnectionSettings(
+    agent_id = os.environ["COPILOT_AGENT_IDENTIFIER"]
+    schema_name = os.environ.get("COPILOT_AGENT_SCHEMA", "").strip()
+    if schema_name:
+        logger.debug(f"Using COPILOT_AGENT_SCHEMA={schema_name!r} for D2E (overrides GUID identifier)")
+        agent_identifier = schema_name
+    elif _UUID_RE.match(agent_id):
+        logger.warning(
+            "COPILOT_AGENT_IDENTIFIER looks like a GUID — "
+            "D2E requires the agent schema name (e.g. cr123_myagent). "
+            "Set COPILOT_AGENT_SCHEMA in .env to fix this."
+        )
+        agent_identifier = agent_id
+    else:
+        agent_identifier = agent_id
+    settings = ConnectionSettings(
         environment_id=os.environ["COPILOT_ENVIRONMENT_ID"],
-        agent_identifier=os.environ["COPILOT_AGENT_IDENTIFIER"],
+        agent_identifier=agent_identifier,
     )
+    url = PowerPlatformEnvironment.get_copilot_studio_connection_url(settings=settings)
+    logger.debug(f"D2E endpoint: {url}")
+    return settings
 
 
 def _get_token() -> str:
-    """Acquire a fresh token (MSAL caches internally)."""
-    return acquire_token(
+    """Acquire a delegated user token for D2E (always browser login, never client credentials)."""
+    logger.debug("Acquiring token (flow=delegated/cached)")
+    token = acquire_token(
         tenant_id=os.environ["AZURE_AD_TENANT_ID"],
         client_id=os.environ["AZURE_AD_CLIENT_ID"],
-        client_secret=os.environ.get("AZURE_AD_CLIENT_SECRET"),
     )
+    logger.debug(f"Token acquired (length={len(token)})")
+    return token
 
 
 async def _ask_question(
@@ -152,17 +246,29 @@ def test_agent(message: str) -> str:
         except Exception as e:
             # SDK throws away the response body — make a raw request to get it
             url = PowerPlatformEnvironment.get_copilot_studio_connection_url(settings=settings)
-            async with aiohttp.ClientSession() as session:
+            req_headers = {
+                "Content-Type": "application/json",
+                "Authorization": f"Bearer {token}",
+                "Accept": "text/event-stream",
+            }
+            req_body = {"emitStartConversationEvent": True}
+            logger.debug(
+                f"[raw fallback] POST {url}\n"
+                f"    Headers: {json.dumps({k: (v[:27] + '...<masked>' if k == 'Authorization' else v) for k, v in req_headers.items()}, indent=6)}\n"
+                f"    Body: {json.dumps(req_body, indent=6)}"
+            )
+            async with aiohttp.ClientSession(trace_configs=[_make_trace_config()]) as session:
                 async with session.post(
                     url,
-                    json={"emitStartConversationEvent": True},
-                    headers={
-                        "Content-Type": "application/json",
-                        "Authorization": f"Bearer {token}",
-                        "Accept": "text/event-stream",
-                    },
+                    json=req_body,
+                    headers=req_headers,
                 ) as resp:
                     body = await resp.text()
+                    logger.error(
+                        f"[raw fallback] {resp.status} {resp.reason}\n"
+                        f"    Headers: {json.dumps(dict(resp.headers), indent=6)}\n"
+                        f"    Body: {body[:2000]}"
+                    )
                     raise RuntimeError(
                         f"D2E returned HTTP {resp.status}\n"
                         f"URL: {url}\n"

--- a/dataverse_client.py
+++ b/dataverse_client.py
@@ -14,7 +14,13 @@ CLI usage:
 import asyncio
 import json
 import os
+import re
 from datetime import datetime, timezone
+
+_UUID_RE = re.compile(
+    r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+    re.IGNORECASE,
+)
 
 import msal
 from loguru import logger
@@ -29,16 +35,24 @@ class DataverseClient:
         org_url: str,
         tenant_id: str,
         client_id: str,
-        client_secret: str,
+        client_secret: str = "",
+        _prefetched_token: str = "",
     ) -> None:
         self.org_url = org_url.rstrip("/")
         self.tenant_id = tenant_id
         self.client_id = client_id
         self.client_secret = client_secret
-        self._token: str | None = None
+        self._token: str | None = _prefetched_token or None
 
     async def _get_token(self) -> str:
-        """Acquire a Dataverse API token via client credentials."""
+        """Acquire a Dataverse API token.
+
+        Returns the pre-fetched token if one was provided at construction,
+        otherwise acquires one via client credentials flow.
+        """
+        if self._token:
+            return self._token
+
         scope = DATAVERSE_SCOPE_TEMPLATE.format(org_url=self.org_url)
         authority = f"https://login.microsoftonline.com/{self.tenant_id}"
 
@@ -56,6 +70,115 @@ class DataverseClient:
 
         logger.info("Dataverse token acquired")
         return result["access_token"]
+
+    async def resolve_bot_guid(self, bot_identifier: str) -> str:
+        """Return the bot's GUID, resolving from schema name if needed.
+
+        If bot_identifier already looks like a UUID it is returned as-is.
+        Otherwise a Dataverse lookup on the bots table is performed using
+        schemaname as the filter. If that returns 403 (no permission to read
+        the bots table), falls back to auto-detecting the GUID from transcripts.
+        """
+        if _UUID_RE.match(bot_identifier):
+            return bot_identifier
+
+        import httpx
+
+        token = await self._get_token()
+        url = (
+            f"{self.org_url}/api/data/v9.2/bots"
+            f"?$filter=schemaname eq '{bot_identifier}'"
+            f"&$select=botid,name"
+        )
+        headers = {
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/json",
+            "OData-MaxVersion": "4.0",
+            "OData-Version": "4.0",
+        }
+        async with httpx.AsyncClient() as client:
+            resp = await client.get(url, headers=headers, timeout=30)
+
+        if resp.status_code == 403:
+            logger.warning(
+                "403 on bots table for '{}' — falling back to transcript-based bot GUID detection",
+                bot_identifier,
+            )
+            return await self._auto_detect_bot_guid()
+
+        resp.raise_for_status()
+
+        bots = resp.json().get("value", [])
+        if not bots:
+            raise RuntimeError(
+                f"No bot found with schemaname '{bot_identifier}' in Dataverse"
+            )
+
+        bot_id = bots[0]["botid"]
+        logger.info("Resolved '{}' → bot GUID {}", bot_identifier, bot_id)
+        return bot_id
+
+    async def _auto_detect_bot_guid(self) -> str:
+        """Detect the bot GUID by sampling recent transcripts.
+
+        Used as a fallback when the bots table returns 403. Fetches the 5 most
+        recent transcripts and extracts unique _bot_conversationtranscriptid_value
+        values. Raises RuntimeError if the result is ambiguous or empty.
+        """
+        import httpx
+
+        token = await self._get_token()
+        url = (
+            f"{self.org_url}/api/data/v9.2/conversationtranscripts"
+            f"?$top=5&$orderby=createdon desc"
+            f"&$select=_bot_conversationtranscriptid_value"
+        )
+        headers = {
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/json",
+            "OData-MaxVersion": "4.0",
+            "OData-Version": "4.0",
+        }
+        async with httpx.AsyncClient() as client:
+            resp = await client.get(url, headers=headers, timeout=30)
+
+        if resp.status_code == 403:
+            raise RuntimeError(
+                "Cannot resolve bot GUID: both the bots table and the unfiltered "
+                "conversationtranscripts table returned 403. "
+                "Set COPILOT_AGENT_IDENTIFIER to the bot UUID directly in your .env file. "
+                "You can find the UUID in the Copilot Studio agent URL or Power Platform admin center."
+            )
+
+        resp.raise_for_status()
+
+        records = resp.json().get("value", [])
+        guids = {
+            r["_bot_conversationtranscriptid_value"]
+            for r in records
+            if r.get("_bot_conversationtranscriptid_value")
+        }
+
+        if len(guids) == 1:
+            guid = guids.pop()
+            logger.warning(
+                "Auto-detected bot GUID {} from transcripts. "
+                "Set COPILOT_AGENT_IDENTIFIER={} to skip this lookup.",
+                guid,
+                guid,
+            )
+            return guid
+
+        if not guids:
+            raise RuntimeError(
+                "Cannot auto-detect bot GUID: no recent transcripts found. "
+                "Set COPILOT_AGENT_IDENTIFIER to the bot UUID directly."
+            )
+
+        raise RuntimeError(
+            f"Multiple bots found in transcripts ({guids}). "
+            "Set COPILOT_AGENT_IDENTIFIER to the bot UUID directly to select one."
+        )
 
     async def fetch_transcripts(
         self,
@@ -75,6 +198,7 @@ class DataverseClient:
         """
         import httpx
 
+        bot_guid = await self.resolve_bot_guid(bot_guid)
         token = await self._get_token()
         since_str = since.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
@@ -102,14 +226,15 @@ class DataverseClient:
         logger.info(f"Fetched {len(records)} transcript(s) from Dataverse")
         return records
 
-    def extract_conversation(self, content_json: str) -> list[dict]:
+    def extract_conversation(self, content_json) -> list[dict]:  # type: ignore[override]
         """Extract message turns from transcript content as a conversation list.
 
         Parses Bot Framework message activities from the content column of a
         conversationtranscript record.
 
         Args:
-            content_json: The JSON string from the 'content' column.
+            content_json: The JSON string from the 'content' column, or an
+                already-parsed list/dict (Dataverse OData sometimes pre-parses it).
 
         Returns:
             List of dicts with keys:
@@ -120,13 +245,25 @@ class DataverseClient:
         if not content_json:
             return []
 
-        try:
-            activities = json.loads(content_json)
-        except (json.JSONDecodeError, TypeError) as e:
-            logger.warning(f"Failed to parse transcript content for conversation: {e}")
-            return []
+        # Handle already-parsed content (OData may return it as list/dict, not string)
+        if isinstance(content_json, (list, dict)):
+            parsed = content_json
+        else:
+            try:
+                parsed = json.loads(content_json)
+            except (json.JSONDecodeError, TypeError) as e:
+                logger.warning(f"Failed to parse transcript content: {e}")
+                return []
 
-        if not isinstance(activities, list):
+        # Handle both flat array and wrapped object formats
+        if isinstance(parsed, dict):
+            activities = parsed.get("activities", parsed.get("value", []))
+            if not isinstance(activities, list):
+                logger.warning(f"Unexpected content dict structure, keys: {list(parsed.keys())[:5]}")
+                return []
+        elif isinstance(parsed, list):
+            activities = parsed
+        else:
             return []
 
         turns: list[dict] = []
@@ -134,21 +271,31 @@ class DataverseClient:
             if activity.get("type") != "message":
                 continue
 
-            text = activity.get("text", "")
+            text = activity.get("text", "") or activity.get("speak", "")
             if not text or not text.strip():
                 continue
 
             from_field = activity.get("from") or {}
-            # Bot Framework: "user" for humans, "bot" for the agent
             raw_role = from_field.get("role", "")
+
             if raw_role == "user":
                 role = "user"
             elif raw_role in ("bot", "skill"):
                 role = "assistant"
+            elif from_field.get("aadObjectId"):
+                # Human users have AAD object IDs; bots don't
+                role = "user"
             else:
-                # Fall back: check from.id — bots often have 'bot' in their id
                 from_id = from_field.get("id", "").lower()
-                role = "user" if ("user" in from_id or not from_id) else "assistant"
+                if "user" in from_id:
+                    role = "user"
+                elif any(x in from_id for x in ("bot", "skill", "agent", "copilot")):
+                    role = "assistant"
+                elif activity.get("replyToId"):
+                    # Bot replies reference the message they're replying to
+                    role = "assistant"
+                else:
+                    role = "user"
 
             turns.append(
                 {
@@ -158,9 +305,18 @@ class DataverseClient:
                 }
             )
 
+        if not turns and activities:
+            types = list({a.get("type", "unknown") for a in activities[:20]})
+            logger.warning(
+                f"No message turns extracted from {len(activities)} activities. "
+                f"Activity types: {types}"
+            )
+
         return turns
 
-    def parse_transcript(self, content_json: str) -> dict:
+    _TOOL_KEYWORDS = ("action", "tool", "knowledge", "plugin", "connector", "invoke", "skill")
+
+    def parse_transcript(self, content_json) -> dict:  # type: ignore[override]
         """Parse the content column of a conversationtranscript record.
 
         Args:
@@ -172,24 +328,36 @@ class DataverseClient:
                 session_info: {"outcome": str}  # Resolved/Escalated/Abandoned
                 dialog_redirects: list of str
                 csat: float | None
+                tools_used: list of str  # deduplicated tool/action/knowledge names
         """
         result: dict = {
             "intent_recognition": [],
             "session_info": {"outcome": ""},
             "dialog_redirects": [],
             "csat": None,
+            "tools_used": [],
         }
 
         if not content_json:
             return result
 
-        try:
-            activities = json.loads(content_json)
-        except (json.JSONDecodeError, TypeError) as e:
-            logger.warning(f"Failed to parse transcript content: {e}")
-            return result
+        # Handle already-parsed content (same as extract_conversation)
+        if isinstance(content_json, (list, dict)):
+            parsed = content_json
+        else:
+            try:
+                parsed = json.loads(content_json)
+            except (json.JSONDecodeError, TypeError) as e:
+                logger.warning(f"Failed to parse transcript content: {e}")
+                return result
 
-        if not isinstance(activities, list):
+        if isinstance(parsed, dict):
+            activities = parsed.get("activities", parsed.get("value", []))
+            if not isinstance(activities, list):
+                return result
+        elif isinstance(parsed, list):
+            activities = parsed
+        else:
             return result
 
         for activity in activities:
@@ -221,6 +389,23 @@ class DataverseClient:
                         result["csat"] = float(raw)
                     except (TypeError, ValueError):
                         pass
+
+            elif value_type and any(kw in value_type.lower() for kw in self._TOOL_KEYWORDS):
+                value = activity.get("value") or {}
+                name = (
+                    value.get("name")
+                    or value.get("actionName")
+                    or value.get("toolName")
+                    or value_type
+                )
+                if name and name not in result["tools_used"]:
+                    result["tools_used"].append(name)
+
+            # Capture invoke-type activities by their activity name
+            if activity.get("type") == "invoke":
+                name = activity.get("name", "")
+                if name and name not in result["tools_used"]:
+                    result["tools_used"].append(name)
 
         return result
 

--- a/docs/plans/2026-03-02-improvements-design.md
+++ b/docs/plans/2026-03-02-improvements-design.md
@@ -1,0 +1,96 @@
+# Targeted Improvements — Design
+
+**Date**: 2026-03-02
+**Approach**: A — four contained fixes, no new dependencies, no DB/schema changes
+
+## Background
+
+The evals platform is a mature MVP for evaluating Copilot Studio agents. Four pain points identified:
+1. Silent metric failures pollute results (reliability)
+2. No live feedback during runs (visibility)
+3. No way to compare runs for regressions (analysis)
+4. Concurrent DeepEval calls spike Azure OAI and trigger 429s (scale)
+
+---
+
+## Fix 1 — Retry with backoff (`eval_engine.py`)
+
+Wrap each `asyncio.to_thread(metric.measure, test_case)` in a retry loop.
+- 3 attempts, exponential backoff: 2s, 4s, 8s
+- On final failure, raise and let the outer `except` in `evaluate_case` handle it (existing error result)
+- No new imports — pure `asyncio.sleep`
+
+```python
+async def _measure_with_retry(metric, test_case, max_attempts=3):
+    for attempt in range(max_attempts):
+        try:
+            await asyncio.to_thread(metric.measure, test_case)
+            return
+        except Exception as e:
+            if attempt == max_attempts - 1:
+                raise
+            delay = 2.0 * (2 ** attempt)
+            logger.warning(f"{type(metric).__name__} attempt {attempt+1} failed: {e}. Retry in {delay}s")
+            await asyncio.sleep(delay)
+```
+
+Replace `await asyncio.to_thread(metric.measure, test_case)` with `await _measure_with_retry(metric, test_case)`.
+
+---
+
+## Fix 2 — Auto-polling on RunDetail (`web/pages/run_detail.py`)
+
+Use `rx.moment` (already available in Reflex) or a conditional `rx.cond` + `rx.call_script` approach.
+Simpler: add `poll_interval` state var. When `run["status"] == "running"`, render an invisible component that triggers `load_run` via `rx.el.div` with a JavaScript `setInterval`.
+
+Cleaner option: Reflex's `@rx.event(background=True)` polling loop:
+- Add `is_live: bool = False` to `RunDetailState`
+- On `load_run`, if status is `running`, set `is_live = True` and start background polling loop
+- Loop calls `load_run` every 3s until status != `running`
+- On page unload or status change, set `is_live = False` to stop
+
+---
+
+## Fix 3 — Run comparison view (`web/pages/runs.py`)
+
+Add to `RunState`:
+- `compare_selected: list[int] = []` — IDs of runs selected for comparison (max 2)
+- `show_compare: bool = False`
+- `compare_data: dict = {}` — loaded comparison data
+
+UI changes:
+- Add checkbox column to `runs_table()`
+- Show "Compare (2)" button in page header when 2 runs selected
+- Comparison modal: table with metric | Run A avg | Run B avg | delta (color-coded ↑↓)
+- Pass rate row at bottom
+
+---
+
+## Fix 4 — Jitter on concurrent DeepEval calls (`eval_engine.py`)
+
+Add random jitter before each metric measure call to spread Azure OAI requests:
+
+```python
+import random
+await asyncio.sleep(random.uniform(0, 1.5))
+await _measure_with_retry(metric, test_case)
+```
+
+This pairs with the existing semaphore to smooth out token-per-minute spikes.
+
+---
+
+## File Impact
+
+| File | Changes |
+|------|---------|
+| `eval_engine.py` | `_measure_with_retry()` helper + jitter (fixes 1 & 4) |
+| `web/pages/run_detail.py` | Background polling loop while status=running (fix 2) |
+| `web/pages/runs.py` | Compare selection + comparison modal (fix 3) |
+
+## Constraints
+
+- No new dependencies
+- No DB schema changes
+- No Docker/port changes
+- No LLM model downgrades

--- a/docs/plans/2026-03-02-targeted-improvements.md
+++ b/docs/plans/2026-03-02-targeted-improvements.md
@@ -1,0 +1,995 @@
+# Targeted Improvements Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Apply four targeted fixes — retry/backoff, jitter, auto-polling, and run comparison — to improve reliability, visibility, and analysis with zero new dependencies.
+
+**Architecture:** Fix 1 & 4 are contained to `eval_engine.py` (add `_measure_with_retry` helper and per-metric jitter). Fix 2 adds a background polling loop in `RunDetailState`. Fix 3 adds compare selection + modal to the Runs page.
+
+**Tech Stack:** Python 3.12, Reflex 0.8.x, DeepEval 2.0, pytest-asyncio, `asyncio` (stdlib only, no new deps)
+
+---
+
+## Task 1: Add `_measure_with_retry` helper to eval_engine.py
+
+**Files:**
+- Modify: `eval_engine.py`
+- Test: `tests/test_eval_engine.py`
+
+### Step 1: Write the failing tests
+
+Add these three tests to `tests/test_eval_engine.py`:
+
+```python
+# --- Retry helper tests ---
+
+@pytest.mark.asyncio
+async def test_measure_with_retry_succeeds_first_try():
+    """No retries when measure succeeds immediately."""
+    from eval_engine import _measure_with_retry
+
+    mock_metric = MagicMock()
+    mock_metric.measure.return_value = None  # sync function, no exception
+
+    with patch("asyncio.sleep") as mock_sleep:
+        await _measure_with_retry(mock_metric, MagicMock())
+
+    mock_metric.measure.assert_called_once()
+    mock_sleep.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_measure_with_retry_succeeds_second_try():
+    """Retries once when first attempt fails."""
+    from eval_engine import _measure_with_retry
+
+    mock_metric = MagicMock()
+    mock_metric.measure.side_effect = [Exception("timeout"), None]
+
+    with patch("eval_engine.asyncio.sleep") as mock_sleep:
+        await _measure_with_retry(mock_metric, MagicMock(), max_attempts=3)
+
+    assert mock_metric.measure.call_count == 2
+    mock_sleep.assert_called_once_with(2.0)
+
+
+@pytest.mark.asyncio
+async def test_measure_with_retry_fails_all_attempts():
+    """Raises after all attempts exhausted."""
+    from eval_engine import _measure_with_retry
+
+    mock_metric = MagicMock()
+    mock_metric.measure.side_effect = Exception("persistent failure")
+
+    with patch("eval_engine.asyncio.sleep") as mock_sleep:
+        with pytest.raises(Exception, match="persistent failure"):
+            await _measure_with_retry(mock_metric, MagicMock(), max_attempts=3)
+
+    assert mock_metric.measure.call_count == 3
+    assert mock_sleep.call_count == 2  # sleeps after attempt 1 and 2
+    calls = [c.args[0] for c in mock_sleep.call_args_list]
+    assert calls == [2.0, 4.0]
+```
+
+### Step 2: Run tests to confirm they fail
+
+```bash
+uv run pytest tests/test_eval_engine.py::test_measure_with_retry_succeeds_first_try tests/test_eval_engine.py::test_measure_with_retry_succeeds_second_try tests/test_eval_engine.py::test_measure_with_retry_fails_all_attempts -v
+```
+
+Expected: `ImportError: cannot import name '_measure_with_retry'`
+
+### Step 3: Implement `_measure_with_retry` in eval_engine.py
+
+Add after the `_build_llm_test_case` function (before `CONVERSATIONAL_METRICS`):
+
+```python
+async def _measure_with_retry(metric, test_case, max_attempts: int = 3) -> None:
+    """Run metric.measure with exponential backoff retry.
+
+    Sleeps 2s, 4s before retries 2 and 3. Raises on final failure.
+    """
+    for attempt in range(max_attempts):
+        try:
+            await asyncio.to_thread(metric.measure, test_case)
+            return
+        except Exception as e:
+            if attempt == max_attempts - 1:
+                raise
+            delay = 2.0 * (2 ** attempt)
+            logger.warning(
+                f"{type(metric).__name__} attempt {attempt + 1} failed: {e}. "
+                f"Retry in {delay}s"
+            )
+            await asyncio.sleep(delay)
+```
+
+Then in `evaluate_case`, replace:
+```python
+await asyncio.to_thread(metric.measure, test_case)
+```
+with:
+```python
+await _measure_with_retry(metric, test_case)
+```
+
+### Step 4: Update the existing error test to patch sleep
+
+The existing `test_evaluate_case_metric_error` test has `mock_metric.measure.side_effect = Exception("API timeout")`. With retry, this now attempts 3 times (with 2+4=6s total sleep). Patch `asyncio.sleep` to keep the test fast:
+
+```python
+@pytest.mark.asyncio
+async def test_evaluate_case_metric_error(mock_env):
+    """Test graceful handling when a metric raises an error (after retries)."""
+    mock_metric = MagicMock()
+    mock_metric.measure.side_effect = Exception("API timeout")
+
+    with (
+        patch("eval_engine._get_judge_model", return_value=_mock_judge()),
+        patch("eval_engine.METRIC_REGISTRY", {
+            "answer_relevancy": lambda model, threshold: mock_metric,
+        }),
+        patch("eval_engine.asyncio.sleep"),  # skip retry delays
+    ):
+        from eval_engine import evaluate_case
+
+        result = await evaluate_case(
+            turns=[{"role": "user", "content": "Test"}],
+            conversation=[
+                {"role": "user", "content": "Test"},
+                {"role": "assistant", "content": "Response"},
+            ],
+            expected_output="",
+            context="",
+            metric_names=["answer_relevancy"],
+            threshold=0.5,
+        )
+
+    assert result["answer_relevancy"]["score"] == 0.0
+    assert "Error" in result["answer_relevancy"]["reason"]
+    assert result["answer_relevancy"]["passed"] is False
+    assert mock_metric.measure.call_count == 3  # 3 attempts before giving up
+```
+
+### Step 5: Run all eval_engine tests
+
+```bash
+uv run pytest tests/test_eval_engine.py -v
+```
+
+Expected: All pass.
+
+### Step 6: Commit
+
+```bash
+git add eval_engine.py tests/test_eval_engine.py
+git commit -m "feat: add retry with exponential backoff for DeepEval metric calls"
+```
+
+---
+
+## Task 2: Add per-metric jitter in eval_engine.py
+
+**Files:**
+- Modify: `eval_engine.py`
+- Test: `tests/test_eval_engine.py`
+
+### Step 1: Write the failing test
+
+Add to `tests/test_eval_engine.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_evaluate_case_jitter_applied(mock_env):
+    """Jitter sleep is called once per AI metric evaluated."""
+    mock_metric = MagicMock()
+    mock_metric.score = 0.8
+    mock_metric.reason = "Good"
+
+    with (
+        patch("eval_engine._get_judge_model", return_value=_mock_judge()),
+        patch("eval_engine.METRIC_REGISTRY", {
+            "answer_relevancy": lambda model, threshold: mock_metric,
+        }),
+        patch("eval_engine.asyncio.sleep") as mock_sleep,
+        patch("eval_engine.random.uniform", return_value=0.5) as mock_uniform,
+    ):
+        from eval_engine import evaluate_case
+
+        await evaluate_case(
+            turns=[{"role": "user", "content": "Test"}],
+            conversation=[
+                {"role": "user", "content": "Test"},
+                {"role": "assistant", "content": "Response"},
+            ],
+            expected_output="",
+            context="",
+            metric_names=["answer_relevancy"],
+            threshold=0.5,
+        )
+
+    mock_uniform.assert_called_once_with(0, 1.5)
+    mock_sleep.assert_called_once_with(0.5)
+```
+
+### Step 2: Run test to confirm it fails
+
+```bash
+uv run pytest tests/test_eval_engine.py::test_evaluate_case_jitter_applied -v
+```
+
+Expected: FAIL — `random.uniform` never called.
+
+### Step 3: Add jitter import and call in eval_engine.py
+
+Add `import random` to the imports at the top of `eval_engine.py`.
+
+In `evaluate_case`, just before `await _measure_with_retry(metric, test_case)`, add:
+
+```python
+await asyncio.sleep(random.uniform(0, 1.5))
+await _measure_with_retry(metric, test_case)
+```
+
+The full try block in evaluate_case should then look like:
+
+```python
+try:
+    if name in CONVERSATIONAL_METRICS:
+        test_case = _build_conversational_test_case(
+            turns, conversation, expected_output, context
+        )
+    else:
+        test_case = _build_llm_test_case(
+            turns, conversation, expected_output, context
+        )
+
+    await asyncio.sleep(random.uniform(0, 1.5))
+    await _measure_with_retry(metric, test_case)
+
+    results[name] = {
+        "score": metric.score,
+        "reason": getattr(metric, "reason", ""),
+        "passed": metric.score >= threshold,
+    }
+    logger.debug(f"Metric {name}: {metric.score:.3f}")
+
+except Exception as e:
+    logger.error(f"Metric {name} failed: {e}")
+    results[name] = {
+        "score": 0.0,
+        "reason": f"Error: {e}",
+        "passed": False,
+    }
+```
+
+### Step 4: Update other tests that patch asyncio.sleep
+
+Any test that patches `eval_engine.asyncio.sleep` (the retry test from Task 1) may now see an extra call from jitter. Check and update if needed.
+
+In `test_measure_with_retry_succeeds_second_try` and `test_measure_with_retry_fails_all_attempts`, the patch is on `eval_engine.asyncio.sleep` directly (used inside `_measure_with_retry`). These tests call `_measure_with_retry` directly, not `evaluate_case`, so jitter doesn't apply. They stay as-is.
+
+### Step 5: Run all eval_engine tests
+
+```bash
+uv run pytest tests/test_eval_engine.py -v
+```
+
+Expected: All pass.
+
+### Step 6: Commit
+
+```bash
+git add eval_engine.py tests/test_eval_engine.py
+git commit -m "feat: add random jitter before AI metric calls to reduce Azure OAI rate limit spikes"
+```
+
+---
+
+## Task 3: Add auto-polling on RunDetail page
+
+**Files:**
+- Modify: `web/pages/run_detail.py`
+
+Note: Reflex state is hard to unit test in isolation. No new test file for this task — manual verification covers it.
+
+### Step 1: Add `is_live` state var to `RunDetailState`
+
+In `web/pages/run_detail.py`, in the `RunDetailState` class, add:
+
+```python
+is_live: bool = False
+```
+
+### Step 2: Add `_refresh_run_data` helper method
+
+This does the actual DB read without touching `is_live`. Extract the core of `load_run` into a private sync method that updates state vars:
+
+Add this private method to `RunDetailState` (above `load_run`):
+
+```python
+def _load_run_data(self, run_id: int) -> None:
+    """Load run + results from DB into state. Does not touch is_live."""
+    with rx.session() as session:
+        run_obj = session.get(EvalRun, run_id)
+        if not run_obj:
+            return
+
+        dataset = session.get(Dataset, run_obj.dataset_id)
+        self.dataset_name = dataset.name if dataset else "Unknown"
+
+        self.run = {
+            "id": run_obj.id,
+            "name": run_obj.name,
+            "status": run_obj.status,
+            "avg_score": (
+                f"{run_obj.avg_score:.1%}"
+                if run_obj.avg_score > 0 else "—"
+            ),
+            "progress": (
+                f"{run_obj.completed_cases}/{run_obj.total_cases}"
+            ),
+            "error": run_obj.error,
+            "created": run_obj.created_at.strftime("%d-%m-%Y %H:%M"),
+        }
+
+        result_rows = session.exec(
+            select(EvalResult)
+            .where(EvalResult.eval_run_id == run_id)
+            .order_by(EvalResult.test_case_index)
+        ).all()
+
+        self.results = []
+        for r in result_rows:
+            scores_raw = (
+                json.loads(r.scores_json) if r.scores_json else {}
+            )
+
+            score_parts = []
+            score_detail_lines = []
+            overall_color = "gray"
+            for mname, data in scores_raw.items():
+                val = (
+                    data.get("score", 0)
+                    if isinstance(data, dict) else 0
+                )
+                reason = (
+                    data.get("reason", "")
+                    if isinstance(data, dict) else ""
+                )
+                color = _color_for_score(val)
+                score_parts.append(f"{mname}: {val:.0%}")
+                detail = f"[{color}] {mname}: {val:.0%}"
+                if reason:
+                    detail += f"\n  {reason}"
+                score_detail_lines.append(detail)
+                if color == "red":
+                    overall_color = "red"
+                elif color == "yellow" and overall_color != "red":
+                    overall_color = "yellow"
+                elif overall_color == "gray":
+                    overall_color = "green"
+
+            scores_summary = " | ".join(score_parts)
+            scores_detail = "\n\n".join(score_detail_lines)
+
+            input_turns = (
+                json.loads(r.input_json) if r.input_json else []
+            )
+            conv_lines = []
+            for t in input_turns:
+                role = (
+                    "User" if t.get("role") == "user"
+                    else "Assistant"
+                )
+                conv_lines.append(f"{role}: {t.get('content', '')}")
+            conversation_text = "\n\n".join(conv_lines)
+
+            raw_activities = (
+                json.loads(r.activities_json) if r.activities_json else []
+            )
+            tool_activities = [
+                a for a in raw_activities
+                if a.get("type") not in (
+                    "message", "end_of_conversation", "typing", None
+                )
+            ]
+            if tool_activities:
+                tool_lines = []
+                for a in tool_activities:
+                    atype = a.get("type", "?")
+                    aname = a.get("name", "")
+                    value = a.get("value") or {}
+
+                    if aname == "DynamicPlanReceived":
+                        steps = value.get("steps", [])
+                        topics = [s.rsplit(".", 1)[-1] for s in steps]
+                        tool_defs = value.get("toolDefinitions", [])
+                        kinds = [
+                            f"{d.get('displayName', '?')} ({d.get('toolKind', '?')})"
+                            for d in tool_defs
+                        ]
+                        line = f"Plan → Topics: {', '.join(topics)}"
+                        if kinds:
+                            line += f"\n  Tools: {', '.join(kinds)}"
+
+                    elif aname == "DynamicPlanStepTriggered":
+                        topic = value.get("taskDialogId", "").rsplit(".", 1)[-1]
+                        state = value.get("state", "?")
+                        step_type = value.get("type", "?")
+                        line = f"Step → {topic} [{step_type}] (state: {state})"
+
+                    elif aname == "DynamicPlanStepBindUpdate":
+                        topic = value.get("taskDialogId", "").rsplit(".", 1)[-1]
+                        args = value.get("arguments", {})
+                        line = f"Bind → {topic}"
+                        if args:
+                            line += f" (args: {args})"
+
+                    else:
+                        line = f"[{atype}] {aname}"
+                        if value:
+                            line += f"\n  {value}"
+
+                    tool_lines.append(line)
+                tool_calls_text = "\n".join(tool_lines)
+            else:
+                tool_calls_text = "No tool activity captured"
+
+            self.results.append({
+                "index": r.test_case_index,
+                "num": str(r.test_case_index + 1),
+                "passed": r.passed,
+                "duration": f"{r.duration_seconds:.1f}s",
+                "actual_output": r.actual_output,
+                "expected_output": r.expected_output,
+                "scores_summary": scores_summary,
+                "scores_detail": scores_detail,
+                "scores_color": overall_color,
+                "conversation_text": conversation_text,
+                "tool_calls_text": tool_calls_text,
+            })
+
+        self.expanded_result = -1
+```
+
+### Step 3: Rewrite `load_run` to use `_load_run_data` and start polling
+
+Replace the existing `load_run` method body:
+
+```python
+def load_run(self) -> None:
+    run_id_str = self.router.page.params.get("run_id", "0")
+    try:
+        run_id = int(run_id_str)
+    except (ValueError, TypeError):
+        return
+
+    self._load_run_data(run_id)
+
+    if self.run.get("status") == "running" and not self.is_live:
+        self.is_live = True
+        return RunDetailState.live_poll(run_id)
+```
+
+### Step 4: Add the `live_poll` background event
+
+Add this method to `RunDetailState`:
+
+```python
+@rx.event(background=True)
+async def live_poll(self, run_id: int) -> None:
+    """Poll DB every 3s while run is still executing."""
+    while True:
+        await asyncio.sleep(3)
+        async with self:
+            self._load_run_data(run_id)
+            if self.run.get("status") not in ("running", "pending"):
+                self.is_live = False
+                break
+```
+
+Add `import asyncio` to `run_detail.py` imports (it's not currently there).
+
+### Step 5: Add a live indicator to the page header
+
+In `_header_section()`, add a live pulse indicator next to the status badge when polling. Find this hstack in `_header_section`:
+
+```python
+rx.hstack(
+    rx.heading(RunDetailState.run["name"], size="6"),
+    status_badge(RunDetailState.run["status"]),
+    rx.spacer(),
+    ...
+```
+
+Add after `status_badge(...)`:
+
+```python
+rx.cond(
+    RunDetailState.is_live,
+    rx.badge("● Live", color_scheme="teal", variant="soft", size="1"),
+),
+```
+
+### Step 6: Manual verification
+
+Start the app, start an eval run with several cases, open Run Detail — verify:
+- "● Live" badge appears while running
+- Progress and results update every ~3s without page reload
+- Badge disappears when run completes
+
+```bash
+uv run reflex run
+```
+
+### Step 7: Commit
+
+```bash
+git add web/pages/run_detail.py
+git commit -m "feat: add live auto-polling on run detail page while run is executing"
+```
+
+---
+
+## Task 4: Add run comparison view to Runs page
+
+**Files:**
+- Modify: `web/pages/runs.py`
+- Test: `tests/test_run_comparison.py`
+
+### Step 1: Write the failing tests
+
+Create `tests/test_run_comparison.py`:
+
+```python
+"""Tests for run comparison state logic."""
+
+import json
+from unittest.mock import MagicMock, patch
+
+
+def _make_run(run_id: int, name: str) -> MagicMock:
+    r = MagicMock()
+    r.id = run_id
+    r.name = name
+    r.avg_score = 0.75
+    r.status = "completed"
+    r.total_cases = 2
+    r.completed_cases = 2
+    r.error = ""
+    return r
+
+
+def _make_result(run_id: int, scores: dict) -> MagicMock:
+    r = MagicMock()
+    r.eval_run_id = run_id
+    r.scores_json = json.dumps(scores)
+    r.passed = all(v.get("passed", False) for v in scores.values())
+    return r
+
+
+def test_toggle_compare_select_adds_run():
+    """Selecting a run adds it to compare_selected."""
+    from web.pages.runs import RunState
+
+    state = RunState()
+    state.compare_selected = []
+    state.toggle_compare(1)
+    assert 1 in state.compare_selected
+
+
+def test_toggle_compare_select_deselects_run():
+    """Selecting an already-selected run removes it."""
+    from web.pages.runs import RunState
+
+    state = RunState()
+    state.compare_selected = [1]
+    state.toggle_compare(1)
+    assert state.compare_selected == []
+
+
+def test_toggle_compare_max_two():
+    """Selecting a third run replaces the oldest selection."""
+    from web.pages.runs import RunState
+
+    state = RunState()
+    state.compare_selected = [1, 2]
+    state.toggle_compare(3)
+    assert state.compare_selected == [2, 3]
+
+
+def test_load_compare_data_structure():
+    """compare_data has correct shape when two runs are loaded."""
+    from web.pages.runs import RunState
+
+    run_a = _make_run(1, "Run A")
+    run_b = _make_run(2, "Run B")
+
+    result_a1 = _make_result(1, {
+        "answer_relevancy": {"score": 0.8, "passed": True},
+    })
+    result_a2 = _make_result(1, {
+        "answer_relevancy": {"score": 0.6, "passed": True},
+    })
+    result_b1 = _make_result(2, {
+        "answer_relevancy": {"score": 0.9, "passed": True},
+    })
+    result_b2 = _make_result(2, {
+        "answer_relevancy": {"score": 0.7, "passed": True},
+    })
+
+    mock_session = MagicMock()
+    mock_session.get.side_effect = lambda model, run_id: (
+        run_a if run_id == 1 else run_b
+    )
+    mock_session.exec.return_value.all.side_effect = [
+        [result_a1, result_a2],
+        [result_b1, result_b2],
+    ]
+
+    state = RunState()
+    state.compare_selected = [1, 2]
+
+    with patch("web.pages.runs.rx.session") as mock_ctx:
+        mock_ctx.return_value.__enter__ = MagicMock(return_value=mock_session)
+        mock_ctx.return_value.__exit__ = MagicMock(return_value=False)
+        state.load_compare_data()
+
+    data = state.compare_data
+    assert data["run_a"]["name"] == "Run A"
+    assert data["run_b"]["name"] == "Run B"
+    assert len(data["metrics"]) == 1
+    metric = data["metrics"][0]
+    assert metric["name"] == "answer_relevancy"
+    assert abs(metric["a_score"] - 0.7) < 0.01   # avg of 0.8 + 0.6
+    assert abs(metric["b_score"] - 0.8) < 0.01   # avg of 0.9 + 0.7
+    assert abs(metric["delta"] - 0.1) < 0.01
+```
+
+### Step 2: Run tests to confirm they fail
+
+```bash
+uv run pytest tests/test_run_comparison.py -v
+```
+
+Expected: Import errors / missing state vars.
+
+### Step 3: Add compare state vars and methods to RunState
+
+In `web/pages/runs.py`, add to `RunState` class:
+
+```python
+# Compare mode
+compare_selected: list[int] = []
+show_compare: bool = False
+compare_data: dict = {}
+
+def toggle_compare(self, run_id: int) -> None:
+    if run_id in self.compare_selected:
+        self.compare_selected = [r for r in self.compare_selected if r != run_id]
+    elif len(self.compare_selected) >= 2:
+        # Drop oldest, add new
+        self.compare_selected = [self.compare_selected[1], run_id]
+    else:
+        self.compare_selected = self.compare_selected + [run_id]
+
+def load_compare_data(self) -> None:
+    if len(self.compare_selected) != 2:
+        return
+
+    run_id_a, run_id_b = self.compare_selected[0], self.compare_selected[1]
+
+    with rx.session() as session:
+        run_a = session.get(EvalRun, run_id_a)
+        run_b = session.get(EvalRun, run_id_b)
+        if not run_a or not run_b:
+            return
+
+        results_a = session.exec(
+            select(EvalResult).where(EvalResult.eval_run_id == run_id_a)
+        ).all()
+        results_b = session.exec(
+            select(EvalResult).where(EvalResult.eval_run_id == run_id_b)
+        ).all()
+
+    def avg_scores(results):
+        totals: dict[str, list[float]] = {}
+        for r in results:
+            scores = json.loads(r.scores_json) if r.scores_json else {}
+            for mname, data in scores.items():
+                if isinstance(data, dict):
+                    totals.setdefault(mname, []).append(data.get("score", 0))
+        return {m: sum(v) / len(v) for m, v in totals.items()}
+
+    def pass_rate(results):
+        if not results:
+            return 0.0
+        return sum(1 for r in results if r.passed) / len(results)
+
+    scores_a = avg_scores(results_a)
+    scores_b = avg_scores(results_b)
+    all_metrics = sorted(set(scores_a) | set(scores_b))
+
+    self.compare_data = {
+        "run_a": {
+            "id": run_a.id,
+            "name": run_a.name,
+            "pass_rate": f"{pass_rate(results_a):.0%}",
+        },
+        "run_b": {
+            "id": run_b.id,
+            "name": run_b.name,
+            "pass_rate": f"{pass_rate(results_b):.0%}",
+        },
+        "metrics": [
+            {
+                "name": m,
+                "a_score": scores_a.get(m, 0),
+                "b_score": scores_b.get(m, 0),
+                "delta": scores_b.get(m, 0) - scores_a.get(m, 0),
+            }
+            for m in all_metrics
+        ],
+    }
+
+def open_compare(self) -> None:
+    self.load_compare_data()
+    self.show_compare = True
+
+def close_compare(self) -> None:
+    self.show_compare = False
+```
+
+### Step 4: Run the comparison tests
+
+```bash
+uv run pytest tests/test_run_comparison.py -v
+```
+
+Expected: All pass.
+
+### Step 5: Add compare checkbox column to `runs_table()`
+
+In `runs_table()`, add a checkbox as the first column header and cell:
+
+Replace `runs_table()` function with:
+
+```python
+def runs_table() -> rx.Component:
+    return rx.table.root(
+        rx.table.header(
+            rx.table.row(
+                rx.table.column_header_cell(""),  # checkbox column
+                rx.table.column_header_cell("Name"),
+                rx.table.column_header_cell("Status"),
+                rx.table.column_header_cell("Progress"),
+                rx.table.column_header_cell("Avg Score"),
+                rx.table.column_header_cell("Created"),
+                rx.table.column_header_cell("Actions"),
+            ),
+        ),
+        rx.table.body(
+            rx.foreach(
+                RunState.runs,
+                lambda r: rx.table.row(
+                    rx.table.cell(
+                        rx.checkbox(
+                            checked=RunState.compare_selected.contains(r["id"]),
+                            on_change=lambda _: RunState.toggle_compare(r["id"]),
+                        ),
+                    ),
+                    rx.table.cell(rx.text(r["name"], weight="medium")),
+                    rx.table.cell(status_badge(r["status"])),
+                    rx.table.cell(
+                        rx.vstack(
+                            rx.progress(value=r["progress_pct"], width="100px"),
+                            rx.text(r["progress"], size="1", color_scheme="gray"),
+                            spacing="1",
+                        ),
+                    ),
+                    rx.table.cell(r["avg_score"]),
+                    rx.table.cell(rx.text(r["created"], size="2", color_scheme="gray")),
+                    rx.table.cell(
+                        rx.hstack(
+                            rx.link(
+                                rx.button(
+                                    rx.icon("eye", size=14),
+                                    variant="ghost",
+                                    size="1",
+                                ),
+                                href="/runs/" + r["id"].to(str),
+                            ),
+                            rx.button(
+                                rx.icon("rotate-cw", size=14),
+                                variant="ghost",
+                                size="1",
+                                on_click=RunState.rerun(r["id"]),
+                            ),
+                            spacing="1",
+                        ),
+                    ),
+                ),
+            ),
+        ),
+        width="100%",
+    )
+```
+
+### Step 6: Add "Compare" button to page header and comparison modal
+
+In `runs_page()`, replace the header hstack with:
+
+```python
+rx.hstack(
+    page_header("Eval Runs", "Configure and run evaluations"),
+    rx.spacer(),
+    rx.cond(
+        RunState.compare_selected.length() == 2,
+        rx.button(
+            rx.icon("git-compare", size=16),
+            "Compare (2)",
+            on_click=RunState.open_compare,
+            variant="soft",
+            size="2",
+        ),
+    ),
+    rx.button(
+        rx.icon("plus", size=16),
+        "New Run",
+        on_click=RunState.open_create_dialog,
+        size="2",
+    ),
+    align="start",
+    width="100%",
+),
+```
+
+Then add a `compare_dialog()` function and call it in `runs_page()`:
+
+```python
+def compare_dialog() -> rx.Component:
+    return rx.dialog.root(
+        rx.dialog.content(
+            rx.dialog.title(
+                rx.hstack(
+                    rx.text("Run Comparison"),
+                    rx.spacer(),
+                    rx.dialog.close(
+                        rx.button(rx.icon("x", size=14), variant="ghost", size="1"),
+                    ),
+                ),
+            ),
+            rx.vstack(
+                # Run names header
+                rx.hstack(
+                    rx.text("Metric", weight="medium", width="160px"),
+                    rx.text(
+                        RunState.compare_data["run_a"]["name"],
+                        weight="medium",
+                        flex="1",
+                        color_scheme="blue",
+                    ),
+                    rx.text(
+                        RunState.compare_data["run_b"]["name"],
+                        weight="medium",
+                        flex="1",
+                        color_scheme="teal",
+                    ),
+                    rx.text("Delta", weight="medium", width="80px"),
+                    width="100%",
+                    spacing="2",
+                ),
+                rx.separator(width="100%"),
+                # Metric rows
+                rx.foreach(
+                    RunState.compare_data["metrics"],
+                    lambda m: rx.hstack(
+                        rx.text(m["name"].to(str), size="2", width="160px"),
+                        rx.text(
+                            (m["a_score"] * 100).to(int).to(str) + "%",
+                            size="2",
+                            flex="1",
+                        ),
+                        rx.text(
+                            (m["b_score"] * 100).to(int).to(str) + "%",
+                            size="2",
+                            flex="1",
+                        ),
+                        rx.cond(
+                            m["delta"] > 0,
+                            rx.badge(
+                                "↑ " + (m["delta"] * 100).to(int).to(str) + "%",
+                                color_scheme="green",
+                                size="1",
+                            ),
+                            rx.cond(
+                                m["delta"] < 0,
+                                rx.badge(
+                                    "↓ " + (m["delta"] * 100).to(int).to(str) + "%",
+                                    color_scheme="red",
+                                    size="1",
+                                ),
+                                rx.badge("—", color_scheme="gray", size="1"),
+                            ),
+                        ),
+                        width="100%",
+                        spacing="2",
+                        align="center",
+                    ),
+                ),
+                rx.separator(width="100%"),
+                # Pass rate row
+                rx.hstack(
+                    rx.text("Pass Rate", size="2", weight="medium", width="160px"),
+                    rx.text(
+                        RunState.compare_data["run_a"]["pass_rate"],
+                        size="2",
+                        flex="1",
+                    ),
+                    rx.text(
+                        RunState.compare_data["run_b"]["pass_rate"],
+                        size="2",
+                        flex="1",
+                    ),
+                    rx.text("", width="80px"),
+                    width="100%",
+                    spacing="2",
+                ),
+                spacing="2",
+                width="100%",
+            ),
+            max_width="600px",
+        ),
+        open=RunState.show_compare,
+        on_open_change=lambda open: rx.cond(
+            open,
+            RunState.open_compare(),
+            RunState.close_compare(),
+        ),
+    )
+```
+
+Add `compare_dialog()` alongside `create_run_dialog()` in `runs_page()`.
+
+### Step 7: Run all tests
+
+```bash
+uv run pytest tests/ -v
+```
+
+Expected: All pass.
+
+### Step 8: Manual verification
+
+Start the app, navigate to /runs, check two completed runs, click "Compare (2)" — verify the side-by-side metric table and delta column render correctly.
+
+### Step 9: Commit
+
+```bash
+git add web/pages/runs.py tests/test_run_comparison.py
+git commit -m "feat: add run comparison modal with per-metric delta view"
+```
+
+---
+
+## Final Check
+
+Run the full test suite one last time:
+
+```bash
+uv run pytest tests/ -v
+```
+
+Run the linter:
+
+```bash
+uv run ruff check . && uv run ruff format --check .
+```
+
+Fix any lint issues, then:
+
+```bash
+git add -p  # stage any lint fixes
+git commit -m "fix: lint cleanup after improvements"
+```

--- a/eval_engine.py
+++ b/eval_engine.py
@@ -5,6 +5,7 @@ Uses Azure OpenAI GPT-4o as judge model.
 
 import asyncio
 import os
+import random
 from typing import Any
 
 from deepeval.metrics import (
@@ -307,7 +308,7 @@ async def evaluate_case(
             else:
                 test_case = _build_llm_test_case(turns, conversation, expected_output, context)
 
-            # DeepEval metrics have a measure() method
+            await asyncio.sleep(random.uniform(0, 1.5))
             await _measure_with_retry(metric, test_case)
 
             results[name] = {

--- a/eval_engine.py
+++ b/eval_engine.py
@@ -64,18 +64,10 @@ METRIC_REGISTRY: dict[str, Any] = {
             LLMTestCaseParams.EXPECTED_OUTPUT,
         ],
     ),
-    "hallucination": lambda model, threshold: HallucinationMetric(
-        model=model, threshold=threshold
-    ),
-    "toxicity": lambda model, threshold: ToxicityMetric(
-        model=model, threshold=threshold
-    ),
-    "bias": lambda model, threshold: BiasMetric(
-        model=model, threshold=threshold
-    ),
-    "faithfulness": lambda model, threshold: FaithfulnessMetric(
-        model=model, threshold=threshold
-    ),
+    "hallucination": lambda model, threshold: HallucinationMetric(model=model, threshold=threshold),
+    "toxicity": lambda model, threshold: ToxicityMetric(model=model, threshold=threshold),
+    "bias": lambda model, threshold: BiasMetric(model=model, threshold=threshold),
+    "faithfulness": lambda model, threshold: FaithfulnessMetric(model=model, threshold=threshold),
 }
 
 
@@ -125,6 +117,25 @@ def _build_llm_test_case(
         kwargs["retrieval_context"] = [context]
 
     return LLMTestCase(**kwargs)
+
+
+async def _measure_with_retry(metric, test_case, max_attempts: int = 3) -> None:
+    """Run metric.measure with exponential backoff retry.
+
+    Sleeps 2s, 4s before retries 2 and 3. Raises on final failure.
+    """
+    for attempt in range(max_attempts):
+        try:
+            await asyncio.to_thread(metric.measure, test_case)
+            return
+        except Exception as e:
+            if attempt == max_attempts - 1:
+                raise
+            delay = 2.0 * (2**attempt)
+            logger.warning(
+                f"{type(metric).__name__} attempt {attempt + 1} failed: {e}. Retry in {delay}s"
+            )
+            await asyncio.sleep(delay)
 
 
 CONVERSATIONAL_METRICS = {
@@ -252,6 +263,8 @@ async def evaluate_case(
             actual_output = msg["content"]
             break
 
+    logger.info(f"Evaluating {len(metric_names)} metrics: {metric_names}")
+
     for name in metric_names:
         # --- Tier 1: deterministic checks ---
         if name == "exact_match":
@@ -292,12 +305,10 @@ async def evaluate_case(
                     turns, conversation, expected_output, context
                 )
             else:
-                test_case = _build_llm_test_case(
-                    turns, conversation, expected_output, context
-                )
+                test_case = _build_llm_test_case(turns, conversation, expected_output, context)
 
             # DeepEval metrics have a measure() method
-            await asyncio.to_thread(metric.measure, test_case)
+            await _measure_with_retry(metric, test_case)
 
             results[name] = {
                 "score": metric.score,

--- a/provisioner.py
+++ b/provisioner.py
@@ -299,6 +299,139 @@ def register_power_platform_admin_app(
     logger.info("Registered app {} as Power Platform admin application", client_id)
 
 
+def _get_org_url_from_env(bap_token: str, environment_id: str) -> str:
+    """Fetch Dataverse org URL for an environment from the BAP API."""
+    headers = {"Authorization": f"Bearer {bap_token}"}
+    resp = httpx.get(
+        f"{_BAP_BASE}/providers/Microsoft.BusinessAppPlatform"
+        f"/environments/{environment_id}?api-version=2021-04-01",
+        headers=headers,
+        timeout=30,
+    )
+    if resp.status_code >= 400:
+        raise RuntimeError(f"Failed to get environment info: {resp.status_code} {resp.text}")
+    env_data = resp.json()
+    org_url = (
+        env_data.get("properties", {})
+        .get("linkedEnvironmentMetadata", {})
+        .get("instanceUrl", "")
+    )
+    if not org_url:
+        raise RuntimeError("Could not find Dataverse org URL for this environment")
+    return org_url.rstrip("/")
+
+
+def add_secret_to_existing_app(graph_token: str, app_client_id: str) -> str:
+    """Add a new client secret to an existing app registration and return it.
+
+    Looks up the app by its appId (client ID), then calls addPassword.
+    Requires Application.ReadWrite.All on the Graph token.
+    """
+    headers = {
+        "Authorization": f"Bearer {graph_token}",
+        "Content-Type": "application/json",
+    }
+    resp = _graph_get(headers, "/applications", {"$filter": f"appId eq '{app_client_id}'"})
+    resp.raise_for_status()
+    apps = resp.json().get("value", [])
+    if not apps:
+        raise RuntimeError(
+            f"App registration with client ID '{app_client_id}' not found in this tenant"
+        )
+    app_object_id = apps[0]["id"]
+
+    secret_body = {"passwordCredential": {"displayName": "mcs-eval-auto"}}
+    resp = _graph_post(headers, f"/applications/{app_object_id}/addPassword", secret_body)
+    if resp.status_code >= 400:
+        raise RuntimeError(f"Failed to add client secret: {resp.status_code} {resp.text}")
+
+    client_secret = resp.json()["secretText"]
+    logger.info("Added client secret to app {}", app_client_id)
+    return client_secret
+
+
+def lookup_env_details_with_credentials(
+    tenant_id: str,
+    client_id: str,
+    client_secret: str,
+    environment_id: str,
+    bot_id: str = "",
+) -> tuple[str, str]:
+    """Fetch (dataverse_org_url, agent_schema_name) using client credentials.
+
+    No device flow needed — uses the existing app registration directly.
+
+    Args:
+        tenant_id: Azure AD tenant ID.
+        client_id: App registration client ID.
+        client_secret: App registration client secret.
+        environment_id: Power Platform environment GUID.
+        bot_id: Bot GUID for schema name lookup; skip lookup if empty string.
+
+    Returns:
+        (org_url, schema_name) — schema_name is "" when bot_id is "".
+    """
+    bap_scope = "https://api.bap.microsoft.com/.default"
+    app = msal.ConfidentialClientApplication(
+        client_id,
+        authority=f"https://login.microsoftonline.com/{tenant_id}",
+        client_credential=client_secret,
+    )
+
+    result = app.acquire_token_for_client(scopes=[bap_scope])
+    if "access_token" not in result:
+        error = result.get("error_description", result.get("error", "Unknown"))
+        raise RuntimeError(f"BAP token failed: {error}")
+
+    org_url = _get_org_url_from_env(result["access_token"], environment_id)
+    logger.info("Dataverse org URL: {}", org_url)
+
+    if not bot_id:
+        return org_url, ""
+
+    dv_result = app.acquire_token_for_client(scopes=[f"{org_url}/.default"])
+    if "access_token" not in dv_result:
+        error = dv_result.get("error_description", dv_result.get("error", "Unknown"))
+        raise RuntimeError(f"Dataverse token failed: {error}")
+
+    headers = {"Authorization": f"Bearer {dv_result['access_token']}"}
+    resp = httpx.get(
+        f"{org_url}/api/data/v9.2/bots({bot_id})",
+        params={"$select": "schemaname,name"},
+        headers=headers,
+        timeout=30,
+    )
+    if resp.status_code >= 400:
+        raise RuntimeError(f"Failed to query bot: {resp.status_code} {resp.text}")
+
+    bot_data = resp.json()
+    schema_name = bot_data.get("schemaname", "")
+    if not schema_name:
+        raise RuntimeError(f"Bot {bot_id} found but has no schemaname")
+
+    logger.info("Agent schema name: {}", schema_name)
+    return org_url, schema_name
+
+
+def lookup_dataverse_org_url(
+    msal_app: msal.PublicClientApplication,
+    environment_id: str,
+) -> str:
+    """Return the Dataverse org URL for the given Power Platform environment.
+
+    Requires a cached BAP token (call after complete_device_flow / register_power_platform_admin_app).
+    """
+    accounts = msal_app.get_accounts()
+    if not accounts:
+        raise RuntimeError("No cached account for org URL lookup")
+    result = msal_app.acquire_token_silent(_BAP_SCOPES, account=accounts[0])
+    if not result or "access_token" not in result:
+        raise RuntimeError("Cannot acquire BAP token silently for org URL lookup")
+    org_url = _get_org_url_from_env(result["access_token"], environment_id)
+    logger.info("Dataverse org URL: {}", org_url)
+    return org_url
+
+
 def lookup_agent_schema_name(
     msal_app: msal.PublicClientApplication,
     environment_id: str,
@@ -321,26 +454,7 @@ def lookup_agent_schema_name(
         bap_token = result["access_token"]
 
     # Step 1: Get environment details to find the Dataverse org URL
-    headers = {"Authorization": f"Bearer {bap_token}"}
-    resp = httpx.get(
-        f"{_BAP_BASE}/providers/Microsoft.BusinessAppPlatform"
-        f"/environments/{environment_id}?api-version=2021-04-01",
-        headers=headers,
-        timeout=30,
-    )
-    if resp.status_code >= 400:
-        raise RuntimeError(f"Failed to get environment info: {resp.status_code} {resp.text}")
-
-    env_data = resp.json()
-    # The org URL is in properties.linkedEnvironmentMetadata.instanceUrl
-    org_url = (
-        env_data.get("properties", {})
-        .get("linkedEnvironmentMetadata", {})
-        .get("instanceUrl", "")
-    )
-    if not org_url:
-        raise RuntimeError("Could not find Dataverse org URL for this environment")
-    org_url = org_url.rstrip("/")
+    org_url = _get_org_url_from_env(bap_token, environment_id)
     logger.info("Dataverse org URL: {}", org_url)
 
     # Step 2: Get a Dataverse token for this org

--- a/retro_eval.py
+++ b/retro_eval.py
@@ -37,6 +37,7 @@ class RetroTestCase:
     dialog_redirects: list[str]
     csat: float | None
     created_at: str | None
+    tools_used: list[str] = field(default_factory=list)
 
 
 @dataclass
@@ -91,13 +92,14 @@ def extract_test_case_from_transcript(
 
     return RetroTestCase(
         transcript_id=transcript_id,
-        conversation=[{"role": t["role"], "content": t["content"]} for t in conversation],
+        conversation=[{"role": t["role"], "content": t["content"], "timestamp": t.get("timestamp")} for t in conversation],
         turns=[{"role": "user", "content": t["content"]} for t in turns],
         intent_recognition=parsed["intent_recognition"],
         session_outcome=parsed["session_info"]["outcome"],
         dialog_redirects=parsed["dialog_redirects"],
         csat=parsed["csat"],
         created_at=transcript.get("createdon"),
+        tools_used=parsed["tools_used"],
     )
 
 

--- a/tests/test_eval_engine.py
+++ b/tests/test_eval_engine.py
@@ -312,6 +312,42 @@ async def test_measure_with_retry_fails_all_attempts():
     assert calls == [2.0, 4.0]
 
 
+@pytest.mark.asyncio
+async def test_evaluate_case_jitter_applied(mock_env):
+    """Jitter sleep is called once per AI metric evaluated."""
+    mock_metric = MagicMock()
+    mock_metric.score = 0.8
+    mock_metric.reason = "Good"
+
+    with (
+        patch("eval_engine._get_judge_model", return_value=_mock_judge()),
+        patch(
+            "eval_engine.METRIC_REGISTRY",
+            {
+                "answer_relevancy": lambda model, threshold: mock_metric,
+            },
+        ),
+        patch("eval_engine.asyncio.sleep") as mock_sleep,
+        patch("eval_engine.random.uniform", return_value=0.5) as mock_uniform,
+    ):
+        from eval_engine import evaluate_case
+
+        await evaluate_case(
+            turns=[{"role": "user", "content": "Test"}],
+            conversation=[
+                {"role": "user", "content": "Test"},
+                {"role": "assistant", "content": "Response"},
+            ],
+            expected_output="",
+            context="",
+            metric_names=["answer_relevancy"],
+            threshold=0.5,
+        )
+
+    mock_uniform.assert_called_once_with(0, 1.5)
+    mock_sleep.assert_called_once_with(0.5)
+
+
 # --- Tier 1 metric tests ---
 
 

--- a/tests/test_eval_engine.py
+++ b/tests/test_eval_engine.py
@@ -26,9 +26,12 @@ async def test_evaluate_case_single_turn(mock_env):
 
     with (
         patch("eval_engine._get_judge_model", return_value=_mock_judge()),
-        patch("eval_engine.METRIC_REGISTRY", {
-            "answer_relevancy": lambda model, threshold: mock_metric,
-        }),
+        patch(
+            "eval_engine.METRIC_REGISTRY",
+            {
+                "answer_relevancy": lambda model, threshold: mock_metric,
+            },
+        ),
     ):
         from eval_engine import evaluate_case
 
@@ -62,10 +65,13 @@ async def test_evaluate_case_multiple_metrics(mock_env):
 
     with (
         patch("eval_engine._get_judge_model", return_value=_mock_judge()),
-        patch("eval_engine.METRIC_REGISTRY", {
-            "answer_relevancy": lambda model, threshold: mock_metric_a,
-            "task_completion": lambda model, threshold: mock_metric_b,
-        }),
+        patch(
+            "eval_engine.METRIC_REGISTRY",
+            {
+                "answer_relevancy": lambda model, threshold: mock_metric_a,
+                "task_completion": lambda model, threshold: mock_metric_b,
+            },
+        ),
     ):
         from eval_engine import evaluate_case
 
@@ -88,15 +94,19 @@ async def test_evaluate_case_multiple_metrics(mock_env):
 
 @pytest.mark.asyncio
 async def test_evaluate_case_metric_error(mock_env):
-    """Test graceful handling when a metric raises an error."""
+    """Test graceful handling when a metric raises an error (after retries)."""
     mock_metric = MagicMock()
     mock_metric.measure.side_effect = Exception("API timeout")
 
     with (
         patch("eval_engine._get_judge_model", return_value=_mock_judge()),
-        patch("eval_engine.METRIC_REGISTRY", {
-            "answer_relevancy": lambda model, threshold: mock_metric,
-        }),
+        patch(
+            "eval_engine.METRIC_REGISTRY",
+            {
+                "answer_relevancy": lambda model, threshold: mock_metric,
+            },
+        ),
+        patch("eval_engine.asyncio.sleep"),  # skip retry delays
     ):
         from eval_engine import evaluate_case
 
@@ -115,6 +125,7 @@ async def test_evaluate_case_metric_error(mock_env):
     assert result["answer_relevancy"]["score"] == 0.0
     assert "Error" in result["answer_relevancy"]["reason"]
     assert result["answer_relevancy"]["passed"] is False
+    assert mock_metric.measure.call_count == 3  # 3 attempts before giving up
 
 
 @pytest.mark.asyncio
@@ -250,13 +261,66 @@ async def test_evaluate_case_topic_routing(mock_env):
     assert result["topic_routing"]["passed"] is True
 
 
+# --- Retry helper tests ---
+
+
+@pytest.mark.asyncio
+async def test_measure_with_retry_succeeds_first_try():
+    """No retries when measure succeeds immediately."""
+    from eval_engine import _measure_with_retry
+
+    mock_metric = MagicMock()
+    mock_metric.measure.return_value = None  # sync function, no exception
+
+    with patch("asyncio.sleep") as mock_sleep:
+        await _measure_with_retry(mock_metric, MagicMock())
+
+    mock_metric.measure.assert_called_once()
+    mock_sleep.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_measure_with_retry_succeeds_second_try():
+    """Retries once when first attempt fails."""
+    from eval_engine import _measure_with_retry
+
+    mock_metric = MagicMock()
+    mock_metric.measure.side_effect = [Exception("timeout"), None]
+
+    with patch("eval_engine.asyncio.sleep") as mock_sleep:
+        await _measure_with_retry(mock_metric, MagicMock(), max_attempts=3)
+
+    assert mock_metric.measure.call_count == 2
+    mock_sleep.assert_called_once_with(2.0)
+
+
+@pytest.mark.asyncio
+async def test_measure_with_retry_fails_all_attempts():
+    """Raises after all attempts exhausted."""
+    from eval_engine import _measure_with_retry
+
+    mock_metric = MagicMock()
+    mock_metric.measure.side_effect = Exception("persistent failure")
+
+    with patch("eval_engine.asyncio.sleep") as mock_sleep:
+        with pytest.raises(Exception, match="persistent failure"):
+            await _measure_with_retry(mock_metric, MagicMock(), max_attempts=3)
+
+    assert mock_metric.measure.call_count == 3
+    assert mock_sleep.call_count == 2  # sleeps after attempt 1 and 2
+    calls = [c.args[0] for c in mock_sleep.call_args_list]
+    assert calls == [2.0, 4.0]
+
+
 # --- Tier 1 metric tests ---
 
 
 def test_exact_match_hit():
     from eval_engine import _evaluate_exact_match
 
-    result = _evaluate_exact_match("Python is a programming language.", "Python is a programming language.")
+    result = _evaluate_exact_match(
+        "Python is a programming language.", "Python is a programming language."
+    )
     assert result["score"] == 1.0
     assert result["passed"] is True
 
@@ -289,7 +353,9 @@ def test_exact_match_no_expected():
 def test_keyword_match_any_one_found():
     from eval_engine import _evaluate_keyword_match
 
-    result = _evaluate_keyword_match("You have 5 vacation days remaining.", ["days remaining", "holiday"], "any")
+    result = _evaluate_keyword_match(
+        "You have 5 vacation days remaining.", ["days remaining", "holiday"], "any"
+    )
     assert result["score"] == 1.0
     assert result["passed"] is True
     assert "days remaining" in result["reason"]
@@ -298,7 +364,9 @@ def test_keyword_match_any_one_found():
 def test_keyword_match_any_none_found():
     from eval_engine import _evaluate_keyword_match
 
-    result = _evaluate_keyword_match("No relevant content here.", ["days remaining", "vacation"], "any")
+    result = _evaluate_keyword_match(
+        "No relevant content here.", ["days remaining", "vacation"], "any"
+    )
     assert result["score"] == 0.0
     assert result["passed"] is False
 

--- a/tests/test_eval_engine.py
+++ b/tests/test_eval_engine.py
@@ -272,7 +272,7 @@ async def test_measure_with_retry_succeeds_first_try():
     mock_metric = MagicMock()
     mock_metric.measure.return_value = None  # sync function, no exception
 
-    with patch("asyncio.sleep") as mock_sleep:
+    with patch("eval_engine.asyncio.sleep") as mock_sleep:
         await _measure_with_retry(mock_metric, MagicMock())
 
     mock_metric.measure.assert_called_once()

--- a/tests/test_run_comparison.py
+++ b/tests/test_run_comparison.py
@@ -1,0 +1,112 @@
+"""Tests for run comparison state logic."""
+
+import json
+from unittest.mock import MagicMock, patch
+
+
+def _make_run(run_id: int, name: str) -> MagicMock:
+    r = MagicMock()
+    r.id = run_id
+    r.name = name
+    r.avg_score = 0.75
+    r.status = "completed"
+    r.total_cases = 2
+    r.completed_cases = 2
+    r.error = ""
+    return r
+
+
+def _make_result(run_id: int, scores: dict) -> MagicMock:
+    r = MagicMock()
+    r.eval_run_id = run_id
+    r.scores_json = json.dumps(scores)
+    r.passed = all(v.get("passed", False) for v in scores.values())
+    return r
+
+
+def test_toggle_compare_select_adds_run():
+    """Selecting a run adds it to compare_selected."""
+    from web.pages.runs import RunState
+
+    state = RunState()
+    state.compare_selected = []
+    state.toggle_compare(1)
+    assert 1 in state.compare_selected
+
+
+def test_toggle_compare_select_deselects_run():
+    """Selecting an already-selected run removes it."""
+    from web.pages.runs import RunState
+
+    state = RunState()
+    state.compare_selected = [1]
+    state.toggle_compare(1)
+    assert state.compare_selected == []
+
+
+def test_toggle_compare_max_two():
+    """Selecting a third run replaces the oldest selection."""
+    from web.pages.runs import RunState
+
+    state = RunState()
+    state.compare_selected = [1, 2]
+    state.toggle_compare(3)
+    assert state.compare_selected == [2, 3]
+
+
+def test_load_compare_data_structure():
+    """compare_data has correct shape when two runs are loaded."""
+    from web.pages.runs import RunState
+
+    run_a = _make_run(1, "Run A")
+    run_b = _make_run(2, "Run B")
+
+    result_a1 = _make_result(
+        1,
+        {
+            "answer_relevancy": {"score": 0.8, "passed": True},
+        },
+    )
+    result_a2 = _make_result(
+        1,
+        {
+            "answer_relevancy": {"score": 0.6, "passed": True},
+        },
+    )
+    result_b1 = _make_result(
+        2,
+        {
+            "answer_relevancy": {"score": 0.9, "passed": True},
+        },
+    )
+    result_b2 = _make_result(
+        2,
+        {
+            "answer_relevancy": {"score": 0.7, "passed": True},
+        },
+    )
+
+    mock_session = MagicMock()
+    mock_session.get.side_effect = lambda model, run_id: run_a if run_id == 1 else run_b
+    mock_session.exec.return_value.all.side_effect = [
+        [result_a1, result_a2],
+        [result_b1, result_b2],
+    ]
+
+    state = RunState()
+    state.compare_selected = [1, 2]
+
+    with patch("web.pages.runs.rx.session") as mock_ctx:
+        mock_ctx.return_value.__enter__ = MagicMock(return_value=mock_session)
+        mock_ctx.return_value.__exit__ = MagicMock(return_value=False)
+        state.load_compare_data()
+
+    data = state.compare_data
+    assert data["run_a"]["name"] == "Run A"
+    assert data["run_b"]["name"] == "Run B"
+    assert len(data["metrics"]) == 1
+    metric = data["metrics"][0]
+    assert metric["name"] == "answer_relevancy"
+    assert abs(metric["a_score"] - 0.7) < 0.01  # avg of 0.8 + 0.6
+    assert abs(metric["b_score"] - 0.8) < 0.01  # avg of 0.9 + 0.7
+    assert abs(metric["delta"] - 0.1) < 0.01

--- a/tests/test_run_comparison.py
+++ b/tests/test_run_comparison.py
@@ -55,7 +55,7 @@ def test_toggle_compare_max_two():
 
 
 def test_load_compare_data_structure():
-    """compare_data has correct shape when two runs are loaded."""
+    """compare_run_a, compare_run_b, compare_metrics populated correctly."""
     from web.pages.runs import RunState
 
     run_a = _make_run(1, "Run A")
@@ -101,12 +101,14 @@ def test_load_compare_data_structure():
         mock_ctx.return_value.__exit__ = MagicMock(return_value=False)
         state.load_compare_data()
 
-    data = state.compare_data
-    assert data["run_a"]["name"] == "Run A"
-    assert data["run_b"]["name"] == "Run B"
-    assert len(data["metrics"]) == 1
-    metric = data["metrics"][0]
+    assert state.compare_run_a["name"] == "Run A"
+    assert state.compare_run_b["name"] == "Run B"
+    assert len(state.compare_metrics) == 1
+
+    metric = state.compare_metrics[0]
     assert metric["name"] == "answer_relevancy"
-    assert abs(metric["a_score"] - 0.7) < 0.01  # avg of 0.8 + 0.6
-    assert abs(metric["b_score"] - 0.8) < 0.01  # avg of 0.9 + 0.7
-    assert abs(metric["delta"] - 0.1) < 0.01
+    assert metric["a_score"] == "70%"  # avg of 0.8 + 0.6 = 0.7 -> 70%
+    assert metric["b_score"] == "80%"  # avg of 0.9 + 0.7 = 0.8 -> 80%
+    assert metric["delta_up"] is True
+    assert metric["delta_down"] is False
+    assert metric["delta_display"] == "10%"  # abs(0.8 - 0.7) = 0.1 -> 10%

--- a/tests/test_run_comparison.py
+++ b/tests/test_run_comparison.py
@@ -111,4 +111,4 @@ def test_load_compare_data_structure():
     assert metric["b_score"] == "80%"  # avg of 0.9 + 0.7 = 0.8 -> 80%
     assert metric["delta_up"] is True
     assert metric["delta_down"] is False
-    assert metric["delta_display"] == "10%"  # abs(0.8 - 0.7) = 0.1 -> 10%
+    assert metric["delta_str"] == "↑ 10%"  # abs(0.8 - 0.7) = 0.1 → 10%

--- a/web/components.py
+++ b/web/components.py
@@ -101,6 +101,7 @@ def sidebar() -> rx.Component:
                 sidebar_link("Dashboard", "/", "layout-dashboard"),
                 sidebar_link("Datasets", "/datasets", "database"),
                 sidebar_link("Eval Runs", "/runs", "play"),
+                sidebar_link("Transcript Extract", "/retro", "history"),
                 sidebar_link("Setup", "/setup", "rocket"),
                 sidebar_link("Settings", "/settings", "settings"),
                 spacing="1",

--- a/web/mermaid.py
+++ b/web/mermaid.py
@@ -1,0 +1,47 @@
+"""Mermaid diagram rendering helpers."""
+import reflex as rx
+
+# JavaScript to reset and re-run Mermaid on all diagram elements.
+# Strip data-processed so Mermaid re-renders even on subsequent selections.
+# Use double-rAF to ensure React has flushed DOM updates before we run.
+MERMAID_RENDER_JS = """
+(function() {
+    function run() {
+        document.querySelectorAll('pre.mermaid').forEach(function(el) {
+            el.removeAttribute('data-processed');
+        });
+        if (typeof mermaid !== 'undefined') {
+            mermaid.run({ querySelector: 'pre.mermaid' });
+        }
+    }
+    requestAnimationFrame(function() { requestAnimationFrame(run); });
+})();
+"""
+
+
+def mermaid_script() -> rx.Component:
+    """Load Mermaid CDN and initialize. Include once per page."""
+    return rx.fragment(
+        rx.script(src="https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.min.js"),
+        rx.script("""
+            (function() {
+                function init() {
+                    if (typeof mermaid === 'undefined') {
+                        setTimeout(init, 100);
+                        return;
+                    }
+                    mermaid.initialize({ startOnLoad: false, theme: 'dark' });
+                }
+                init();
+            })();
+        """),
+    )
+
+
+def mermaid_diagram(content: rx.Var) -> rx.Component:
+    """Render a mermaid diagram from a reactive state var."""
+    return rx.box(
+        rx.el.pre(content, class_name="mermaid"),
+        width="100%",
+        overflow_x="auto",
+    )

--- a/web/pages/retro.py
+++ b/web/pages/retro.py
@@ -1,0 +1,706 @@
+"""Retro Evals page — run historical transcript evaluations."""
+
+import asyncio
+import json
+import os
+from datetime import datetime, timedelta, timezone
+
+import reflex as rx
+from sqlmodel import select
+
+from web.components import empty_state, layout, page_header, stat_card, status_badge
+from web.models import EvalResult, EvalRun
+from web.state import State
+
+
+class RetroState(State):
+    since_str: str = ""
+    top: int = 100
+    expected_topic: str = ""
+    status: str = "idle"  # idle | fetching | evaluating | completed | error
+    error: str = ""
+    last_run_id: int = 0
+    total_fetched: int = 0
+    total_evaluated: int = 0
+    total_skipped: int = 0
+    outcome_resolved: int = 0
+    outcome_escalated: int = 0
+    outcome_abandoned: int = 0
+    topic_pass_rate: str = "—"
+    avg_csat: str = "—"
+    recent_runs: list[dict] = []
+    missing_env_vars: list[str] = []
+    device_code: str = ""
+    device_code_url: str = ""
+
+    @rx.var
+    def progress_text(self) -> str:
+        return f"Evaluating {self.total_evaluated} / {self.total_fetched}..."
+
+    @rx.var
+    def run_disabled(self) -> bool:
+        return self.status not in ("idle", "error", "completed")
+
+    def load_page(self) -> None:
+        if not self.since_str:
+            since_dt = datetime.now(timezone.utc) - timedelta(days=7)
+            self.since_str = since_dt.strftime("%Y-%m-%d")
+
+        required_env = [
+            "COPILOT_AGENT_IDENTIFIER",
+            "DATAVERSE_ORG_URL",
+            "AZURE_AD_TENANT_ID",
+            "AZURE_AD_CLIENT_ID",
+        ]
+        self.missing_env_vars = [k for k in required_env if not os.environ.get(k)]
+
+        with rx.session() as session:
+            rows = session.exec(
+                select(EvalRun).order_by(EvalRun.created_at.desc())
+            ).all()
+
+        retro_rows = []
+        for r in rows:
+            try:
+                cfg = json.loads(r.config_json) if r.config_json else {}
+            except Exception:
+                cfg = {}
+            if cfg.get("run_type") != "retro":
+                continue
+            retro_rows.append({
+                "id": r.id,
+                "name": r.name,
+                "status": r.status,
+                "total_cases": r.total_cases,
+                "avg_score": f"{r.avg_score:.0%}" if r.avg_score > 0 else "—",
+                "created": r.created_at.strftime("%d-%m-%Y %H:%M"),
+            })
+
+        self.recent_runs = retro_rows
+
+    def set_since_str(self, value: str) -> None:
+        self.since_str = value
+
+    def set_top(self, value: str) -> None:
+        try:
+            self.top = max(1, int(value)) if value else 100
+        except ValueError:
+            self.top = 100
+
+    def set_expected_topic(self, value: str) -> None:
+        self.expected_topic = value
+
+    def delete_run(self, run_id: int) -> None:
+        with rx.session() as session:
+            results = session.exec(
+                select(EvalResult).where(EvalResult.eval_run_id == run_id)
+            ).all()
+            for r in results:
+                session.delete(r)
+            run_obj = session.get(EvalRun, run_id)
+            if run_obj:
+                session.delete(run_obj)
+            session.commit()
+        self.recent_runs = [r for r in self.recent_runs if r["id"] != run_id]
+
+    @rx.event(background=True)
+    async def execute_retro_run(self) -> None:
+        # Step 1: Validate env vars (client secret is optional — device flow used if absent)
+        required_env = [
+            "COPILOT_AGENT_IDENTIFIER",
+            "DATAVERSE_ORG_URL",
+            "AZURE_AD_TENANT_ID",
+            "AZURE_AD_CLIENT_ID",
+        ]
+        missing = [k for k in required_env if not os.environ.get(k)]
+        if missing:
+            async with self:
+                self.status = "error"
+                self.error = f"Missing environment variables: {', '.join(missing)}"
+            return
+
+        # Step 2 & 3: Guard + snapshot config + reset counters
+        async with self:
+            if self.status not in ("idle", "error", "completed"):
+                return
+            since_str = self.since_str
+            top = self.top
+            expected_topic = self.expected_topic
+            self.status = "fetching"
+            self.error = ""
+            self.total_fetched = 0
+            self.total_evaluated = 0
+            self.total_skipped = 0
+            self.outcome_resolved = 0
+            self.outcome_escalated = 0
+            self.outcome_abandoned = 0
+            self.topic_pass_rate = "—"
+            self.avg_csat = "—"
+
+        # Step 4: Create EvalRun
+        config = {
+            "run_type": "retro",
+            "since": since_str,
+            "top": top,
+            "expected_topic": expected_topic,
+        }
+        run_name = f"Transcript Extract {since_str} (top {top})"
+        run_id: int = 0
+
+        async with self:
+            with rx.session() as session:
+                run_obj = EvalRun(
+                    name=run_name,
+                    dataset_id=0,
+                    status="running",
+                    config_json=json.dumps(config),
+                    metrics_json=json.dumps(["topic_routing"]),
+                    total_cases=0,
+                )
+                session.add(run_obj)
+                session.commit()
+                session.refresh(run_obj)
+                run_id = run_obj.id
+            self.last_run_id = run_id
+
+        # Step 5: Fetch transcripts
+        try:
+            from dataverse_client import DataverseClient  # noqa: PLC0415
+            from dotenv import load_dotenv  # noqa: PLC0415
+            load_dotenv(override=True)
+
+            since_dt = datetime.fromisoformat(since_str).replace(tzinfo=timezone.utc)
+            bot_guid = os.environ["COPILOT_AGENT_IDENTIFIER"]
+            org_url = os.environ["DATAVERSE_ORG_URL"]
+            tenant_id_env = os.environ["AZURE_AD_TENANT_ID"]
+            client_id_env = os.environ["AZURE_AD_CLIENT_ID"]
+            # Always use device flow for Dataverse — client credentials don't have
+            # Dataverse table access unless the app is registered as a Dataverse
+            # application user, which is a separate setup step.
+            import msal  # noqa: PLC0415
+            _CLI_CLIENT_ID = "04b07795-8ddb-461a-bbee-02f9e1bf7b46"
+            msal_app = msal.PublicClientApplication(
+                _CLI_CLIENT_ID,
+                authority=f"https://login.microsoftonline.com/{tenant_id_env}",
+            )
+            flow = msal_app.initiate_device_flow(scopes=[f"{org_url}/.default"])
+            if "user_code" not in flow:
+                raise RuntimeError(f"Device flow initiation failed: {flow}")
+
+            async with self:
+                self.device_code = flow["user_code"]
+                self.device_code_url = flow["verification_uri"]
+
+            import webbrowser  # noqa: PLC0415
+            webbrowser.open(flow["verification_uri"])
+
+            result = await asyncio.to_thread(msal_app.acquire_token_by_device_flow, flow)
+            if "access_token" not in result:
+                raise RuntimeError(
+                    f"Device flow login failed: {result.get('error_description', result.get('error'))}"
+                )
+
+            async with self:
+                self.device_code = ""
+                self.device_code_url = ""
+
+            dv_client = DataverseClient(
+                org_url=org_url,
+                tenant_id=tenant_id_env,
+                client_id=client_id_env,
+                _prefetched_token=result["access_token"],
+            )
+
+            transcripts = await dv_client.fetch_transcripts(bot_guid, since_dt, top=top)
+        except Exception as exc:
+            async with self:
+                self.status = "error"
+                self.error = str(exc)
+                with rx.session() as session:
+                    failed = session.get(EvalRun, run_id)
+                    if failed:
+                        failed.status = "failed"
+                        failed.error = str(exc)
+                        session.add(failed)
+                        session.commit()
+            return
+
+        # Step 6: Update total_cases, move to evaluating
+        async with self:
+            self.total_fetched = len(transcripts)
+            self.status = "evaluating"
+            with rx.session() as session:
+                run_obj = session.get(EvalRun, run_id)
+                if run_obj:
+                    run_obj.total_cases = len(transcripts)
+                    session.add(run_obj)
+                    session.commit()
+
+        # Step 7: Process each transcript
+        from retro_eval import (  # noqa: PLC0415
+            extract_test_case_from_transcript,
+            run_tier1_metrics,
+        )
+
+        all_topic_pass: list[bool] = []
+        all_csat: list[float] = []
+        outcome_counts: dict[str, int] = {"Resolved": 0, "Escalated": 0, "Abandoned": 0}
+
+        for idx, transcript in enumerate(transcripts):
+            test_case = extract_test_case_from_transcript(transcript, dv_client)
+
+            if test_case is None:
+                async with self:
+                    self.total_skipped += 1
+                    with rx.session() as session:
+                        run_obj = session.get(EvalRun, run_id)
+                        if run_obj:
+                            run_obj.completed_cases += 1
+                            session.add(run_obj)
+                            session.commit()
+                continue
+
+            metric_results = run_tier1_metrics(test_case, expected_topic=expected_topic)
+
+            outcome = test_case.session_outcome or "Unknown"
+            if outcome in outcome_counts:
+                outcome_counts[outcome] += 1
+            if test_case.csat is not None:
+                all_csat.append(test_case.csat)
+            for m, r in metric_results.items():
+                if m == "topic_routing":
+                    all_topic_pass.append(r.get("passed", False))
+
+            activities = [
+                {
+                    "type": "retro_info",
+                    "session_outcome": outcome,
+                    "csat": test_case.csat,
+                    "transcript_id": test_case.transcript_id,
+                    "conversation_length": len(test_case.conversation),
+                    "tools_used": test_case.tools_used,
+                    "intent_recognition": test_case.intent_recognition,
+                    "dialog_redirects": test_case.dialog_redirects,
+                }
+            ]
+
+            avg_case_score = (
+                sum(r.get("score", 0) for r in metric_results.values()) / len(metric_results)
+                if metric_results
+                else 0.0
+            )
+            passed = avg_case_score >= 0.5
+            actual_output = ""
+            if test_case.conversation:
+                for msg in reversed(test_case.conversation):
+                    if msg.get("role") == "assistant":
+                        actual_output = msg.get("content", "")
+                        break
+
+            async with self:
+                self.total_evaluated += 1
+                with rx.session() as session:
+                    result = EvalResult(
+                        eval_run_id=run_id,
+                        test_case_index=idx,
+                        input_json=json.dumps(test_case.conversation),
+                        actual_output=actual_output,
+                        expected_output="",
+                        scores_json=json.dumps(metric_results),
+                        activities_json=json.dumps(activities),
+                        passed=passed,
+                        duration_seconds=0.0,
+                    )
+                    session.add(result)
+                    run_obj = session.get(EvalRun, run_id)
+                    if run_obj:
+                        run_obj.completed_cases += 1
+                        session.add(run_obj)
+                    session.commit()
+
+        # Step 8: Finalize run
+        topic_rate = sum(all_topic_pass) / len(all_topic_pass) if all_topic_pass else 0.0
+        avg_csat_val = sum(all_csat) / len(all_csat) if all_csat else None
+
+        async with self:
+            with rx.session() as session:
+                run_obj = session.get(EvalRun, run_id)
+                if run_obj:
+                    run_obj.status = "completed"
+                    run_obj.avg_score = topic_rate
+                    run_obj.completed_at = datetime.utcnow()
+                    session.add(run_obj)
+                    session.commit()
+
+            # Step 9: Update outcome / CSAT / pass-rate state vars
+            self.outcome_resolved = outcome_counts.get("Resolved", 0)
+            self.outcome_escalated = outcome_counts.get("Escalated", 0)
+            self.outcome_abandoned = outcome_counts.get("Abandoned", 0)
+            self.topic_pass_rate = f"{topic_rate:.0%}" if all_topic_pass else "—"
+            self.avg_csat = f"{avg_csat_val:.1f}" if avg_csat_val is not None else "—"
+            self.status = "completed"
+
+            # Step 10: Refresh recent runs table
+            self.load_page()
+
+
+# ---------------------------------------------------------------------------
+# UI components
+# ---------------------------------------------------------------------------
+
+
+def _config_card() -> rx.Component:
+    return rx.card(
+        rx.vstack(
+            rx.hstack(
+                rx.icon("history", size=16, color="var(--accent-9)"),
+                rx.text("Configuration", size="3", weight="bold"),
+                spacing="2",
+                align="center",
+            ),
+            rx.grid(
+                rx.vstack(
+                    rx.text("Since Date", size="2", weight="medium"),
+                    rx.input(
+                        value=RetroState.since_str,
+                        on_change=RetroState.set_since_str,
+                        type="date",
+                        width="100%",
+                    ),
+                    spacing="1",
+                    width="100%",
+                ),
+                rx.vstack(
+                    rx.text("Top N Transcripts", size="2", weight="medium"),
+                    rx.input(
+                        value=RetroState.top.to(str),
+                        on_change=RetroState.set_top,
+                        type="number",
+                        width="100%",
+                    ),
+                    spacing="1",
+                    width="100%",
+                ),
+                rx.vstack(
+                    rx.text("Expected Topic (optional)", size="2", weight="medium"),
+                    rx.input(
+                        value=RetroState.expected_topic,
+                        on_change=RetroState.set_expected_topic,
+                        placeholder="e.g. Billing",
+                        width="100%",
+                    ),
+                    spacing="1",
+                    width="100%",
+                ),
+                columns="3",
+                gap="4",
+                width="100%",
+            ),
+            rx.button(
+                rx.icon("play", size=14),
+                "Transcript Extract",
+                on_click=RetroState.execute_retro_run,
+                disabled=RetroState.run_disabled,
+                size="2",
+            ),
+            spacing="4",
+            width="100%",
+        ),
+        width="100%",
+    )
+
+
+def _status_bar() -> rx.Component:
+    device_code_callout = rx.cond(
+        RetroState.device_code != "",
+        rx.callout(
+            rx.vstack(
+                rx.text(
+                    "A browser window has opened. Enter this code when prompted:",
+                    size="2",
+                ),
+                rx.heading(RetroState.device_code, size="6"),
+                rx.hstack(
+                    rx.text("Or go to: ", size="2"),
+                    rx.link(
+                        RetroState.device_code_url,
+                        href=RetroState.device_code_url,
+                        is_external=True,
+                        size="2",
+                    ),
+                    spacing="1",
+                    align="center",
+                ),
+                spacing="2",
+                align="center",
+            ),
+            icon="key",
+            color_scheme="blue",
+            width="100%",
+        ),
+    )
+
+    run_status_card = rx.card(
+        rx.cond(
+            RetroState.status == "completed",
+            rx.hstack(
+                rx.icon("check-circle", size=16, color="#34d399"),
+                rx.text("Run completed.", size="2", weight="medium"),
+                rx.link(
+                    rx.hstack(
+                        rx.text("View detail", size="2"),
+                        rx.icon("arrow-up-right", size=12),
+                        spacing="1",
+                        align="center",
+                    ),
+                    href="/runs/" + RetroState.last_run_id.to(str),
+                    underline="none",
+                    color="var(--accent-9)",
+                ),
+                spacing="3",
+                align="center",
+            ),
+            rx.cond(
+                RetroState.status == "error",
+                rx.callout(
+                    RetroState.error,
+                    icon="triangle_alert",
+                    color_scheme="red",
+                    width="100%",
+                ),
+                rx.hstack(
+                    rx.spinner(size="2"),
+                    rx.cond(
+                        RetroState.status == "fetching",
+                        rx.text("Fetching transcripts from Dataverse...", size="2"),
+                        rx.text(RetroState.progress_text, size="2"),
+                    ),
+                    spacing="3",
+                    align="center",
+                ),
+            ),
+        ),
+        width="100%",
+    )
+
+    return rx.cond(
+        RetroState.status != "idle",
+        rx.vstack(
+            device_code_callout,
+            run_status_card,
+            width="100%",
+        ),
+    )
+
+
+def _summary_stats() -> rx.Component:
+    return rx.cond(
+        RetroState.status == "completed",
+        rx.grid(
+            stat_card(
+                "Resolved",
+                RetroState.outcome_resolved.to(str),
+                "check-circle",
+                "green",
+            ),
+            stat_card(
+                "Escalated",
+                RetroState.outcome_escalated.to(str),
+                "arrow-up-right",
+                "orange",
+            ),
+            stat_card(
+                "Abandoned",
+                RetroState.outcome_abandoned.to(str),
+                "x-circle",
+                "red",
+            ),
+            stat_card(
+                "Topic Pass Rate",
+                RetroState.topic_pass_rate,
+                "target",
+                "teal",
+            ),
+            stat_card(
+                "Avg CSAT",
+                RetroState.avg_csat,
+                "star",
+                "yellow",
+            ),
+            columns="5",
+            gap="3",
+            width="100%",
+        ),
+    )
+
+
+def _recent_runs_table() -> rx.Component:
+    return rx.vstack(
+        rx.hstack(
+            rx.hstack(
+                rx.icon("history", size=16, color="var(--accent-9)"),
+                rx.text("Recent Runs", size="3", weight="bold"),
+                rx.badge(
+                    RetroState.recent_runs.length().to(str),
+                    variant="soft",
+                    color_scheme="gray",
+                    size="1",
+                ),
+                spacing="2",
+                align="center",
+            ),
+            width="100%",
+        ),
+        rx.cond(
+            RetroState.recent_runs.length() > 0,
+            rx.table.root(
+                rx.table.header(
+                    rx.table.row(
+                        rx.table.column_header_cell("Name"),
+                        rx.table.column_header_cell("Status"),
+                        rx.table.column_header_cell("Transcripts"),
+                        rx.table.column_header_cell("Avg Score"),
+                        rx.table.column_header_cell("Created"),
+                        rx.table.column_header_cell(""),
+                        rx.table.column_header_cell(""),
+                        rx.table.column_header_cell(""),
+                    ),
+                ),
+                rx.table.body(
+                    rx.foreach(
+                        RetroState.recent_runs,
+                        lambda r: rx.table.row(
+                            rx.table.cell(
+                                rx.link(
+                                    rx.hstack(
+                                        rx.text(r["name"], weight="medium", size="2"),
+                                        rx.icon(
+                                            "arrow-up-right",
+                                            size=12,
+                                            color="var(--gray-a7)",
+                                        ),
+                                        spacing="1",
+                                        align="center",
+                                    ),
+                                    href="/runs/" + r["id"].to(str),
+                                    underline="none",
+                                    class_name="run-name-link",
+                                ),
+                            ),
+                            rx.table.cell(status_badge(r["status"])),
+                            rx.table.cell(
+                                rx.text(
+                                    r["total_cases"].to(str),
+                                    size="2",
+                                    font_family="var(--font-mono)",
+                                ),
+                            ),
+                            rx.table.cell(
+                                rx.text(
+                                    r["avg_score"],
+                                    size="2",
+                                    font_family="var(--font-mono)",
+                                    weight="medium",
+                                ),
+                            ),
+                            rx.table.cell(
+                                rx.text(
+                                    r["created"],
+                                    size="1",
+                                    color="var(--gray-a8)",
+                                    font_family="var(--font-mono)",
+                                ),
+                            ),
+                            rx.table.cell(
+                                rx.cond(
+                                    r["status"] == "completed",
+                                    rx.link(
+                                        rx.hstack(
+                                            rx.icon("database", size=12),
+                                            rx.text("Build Dataset", size="1"),
+                                            spacing="1",
+                                            align="center",
+                                        ),
+                                        href="/retro/suggest/" + r["id"].to(str),
+                                        underline="none",
+                                        color="var(--accent-9)",
+                                    ),
+                                ),
+                            ),
+                            rx.table.cell(
+                                rx.cond(
+                                    r["status"] == "completed",
+                                    rx.link(
+                                        rx.hstack(
+                                            rx.icon("messages-square", size=12),
+                                            rx.text("View Conversations", size="1"),
+                                            spacing="1",
+                                            align="center",
+                                        ),
+                                        href="/retro/conversations/" + r["id"].to(str),
+                                        underline="none",
+                                        color="var(--accent-9)",
+                                    ),
+                                ),
+                            ),
+                            rx.table.cell(
+                                rx.icon_button(
+                                    rx.icon("trash-2", size=14),
+                                    size="1",
+                                    variant="ghost",
+                                    color_scheme="red",
+                                    on_click=RetroState.delete_run(r["id"]),
+                                ),
+                            ),
+                        ),
+                    ),
+                ),
+                width="100%",
+            ),
+            empty_state("No retro eval runs yet. Configure above and click Run.", "history"),
+        ),
+        spacing="3",
+        width="100%",
+    )
+
+
+def _missing_vars_callout() -> rx.Component:
+    return rx.cond(
+        RetroState.missing_env_vars.length() > 0,
+        rx.callout(
+            rx.hstack(
+                rx.text(
+                    "Missing Dataverse credentials. Configure them in ",
+                    size="2",
+                ),
+                rx.link("Settings", href="/settings", size="2", underline="always"),
+                rx.text(" before running.", size="2"),
+                spacing="1",
+                align="center",
+                flex_wrap="wrap",
+            ),
+            icon="triangle_alert",
+            color_scheme="amber",
+            width="100%",
+        ),
+    )
+
+
+@rx.page(route="/retro", title="Transcript Extract", on_load=RetroState.load_page)
+def retro_page() -> rx.Component:
+    return layout(
+        rx.vstack(
+            page_header(
+                "Transcript Extract",
+                "Evaluate historical Copilot Studio transcripts from Dataverse",
+            ),
+            _missing_vars_callout(),
+            _config_card(),
+            _status_bar(),
+            _summary_stats(),
+            rx.separator(),
+            _recent_runs_table(),
+            spacing="4",
+            width="100%",
+        ),
+    )

--- a/web/pages/retro_conversations.py
+++ b/web/pages/retro_conversations.py
@@ -1,0 +1,783 @@
+"""Conversation viewer — drill into individual conversations from a retro eval run."""
+
+import json
+from datetime import datetime
+
+import reflex as rx
+from sqlmodel import select
+
+from web.components import empty_state, layout
+from web.mermaid import MERMAID_RENDER_JS, mermaid_diagram, mermaid_script
+from web.models import EvalResult, EvalRun
+from web.state import State
+
+
+# ---------------------------------------------------------------------------
+# Diagram builder helpers
+# ---------------------------------------------------------------------------
+
+
+def _sanitize(text: str) -> str:
+    """Remove Mermaid-conflicting characters and truncate."""
+    text = text.replace("\r\n", " ").replace("\n", " ").replace("\r", " ")
+    for ch in ('"', "'", "#", ";", "{", "}", "|", "<", ">"):
+        text = text.replace(ch, " ")
+    return text[:80]
+
+
+def _make_pid(name: str) -> str:
+    """Create a valid Mermaid participant ID from a topic name."""
+    return "".join(c for c in name if c.isalnum() or c == "_") or "Unknown"
+
+
+def build_sequence_mermaid(
+    messages: list[dict],
+    intent_recognition: list[dict],
+    dialog_redirects: list[str],
+    tools_used: list[str],
+    outcome: str,
+) -> str:
+    lines = ["sequenceDiagram"]
+
+    # Collect unique topic participants
+    topics: list[str] = []
+    seen_topics: set[str] = set()
+    for intent in intent_recognition:
+        t = intent.get("topic", "")
+        if t and t not in seen_topics:
+            topics.append(t)
+            seen_topics.add(t)
+    for rd in dialog_redirects:
+        if rd and rd not in seen_topics:
+            topics.append(rd)
+            seen_topics.add(rd)
+
+    lines.append("    participant User")
+    lines.append("    participant Orchestrator")
+    for t in topics:
+        pid = _make_pid(t)
+        lines.append(f"    participant {pid} as Topic - {_sanitize(t)}")
+
+    # Interleave messages and routing events
+    routing_inserted = False
+    for msg in messages:
+        content = _sanitize(msg.get("content", ""))
+        if msg["role"] == "user":
+            lines.append(f"    User->>Orchestrator: {content}")
+            if not routing_inserted:
+                for intent in intent_recognition:
+                    t = _sanitize(intent.get("topic", ""))
+                    score = intent.get("score", 0) or 0
+                    pct = int(float(score) * 100) if float(score) <= 1.0 else int(float(score))
+                    lines.append(f"    Note over Orchestrator: Plan - {t} ({pct}%)")
+                for rd in dialog_redirects:
+                    pid = _make_pid(rd)
+                    lines.append(f"    Orchestrator->>{pid}: Execute {_sanitize(rd)}")
+                    state = "failed" if outcome in ("Escalated", "Abandoned") else "done"
+                    if state == "failed":
+                        lines.append(f"    {pid}-->>Orchestrator: failed")
+                    else:
+                        lines.append(f"    {pid}->>Orchestrator: done")
+                if tools_used:
+                    tools_str = ", ".join(_sanitize(t) for t in tools_used[:4])
+                    lines.append(f"    Note over Orchestrator: Tools: {tools_str}")
+                routing_inserted = True
+        else:
+            lines.append(f"    Orchestrator->>User: {content}")
+
+    lines.append(f"    Note over Orchestrator: Outcome: {outcome}")
+    return "\n".join(lines)
+
+
+def build_gantt_mermaid(
+    messages: list[dict],
+    intent_recognition: list[dict],
+    dialog_redirects: list[str],
+    outcome: str,
+) -> str:
+    MIN_DURATION_MS = 50
+
+    timed: list[tuple[int, str, str]] = []
+    has_ts = False
+    t_origin: int | None = None
+
+    for msg in messages:
+        ts_raw = msg.get("timestamp")
+        if ts_raw:
+            try:
+                dt = datetime.fromisoformat(ts_raw.replace("Z", "+00:00"))
+                epoch_ms = int(dt.timestamp() * 1000)
+                if t_origin is None:
+                    t_origin = epoch_ms
+                timed.append((epoch_ms - t_origin, msg["role"], msg.get("content", "")[:40]))
+                has_ts = True
+            except Exception:
+                pass
+
+    if not has_ts:
+        for i, msg in enumerate(messages):
+            timed.append((i * 1000, msg["role"], msg.get("content", "")[:40]))
+
+    lines = [
+        "gantt",
+        "    dateFormat x",
+        "    axisFormat %M:%S",
+        "    title Execution Timeline",
+    ]
+
+    lines.append("    section User")
+    event_idx = 0
+    for ms, role, content in timed:
+        if role == "user":
+            label = _sanitize(content)
+            lines.append(f"    {label} :active, e{event_idx}, {ms}, {ms + MIN_DURATION_MS}")
+            event_idx += 1
+
+    lines.append("    section Orchestrator")
+    first_user_ms = next((ms for ms, role, _ in timed if role == "user"), 0)
+    offset = first_user_ms + MIN_DURATION_MS
+    for intent in intent_recognition:
+        t = _sanitize(intent.get("topic", ""))
+        score = intent.get("score", 0) or 0
+        pct = int(float(score) * 100) if float(score) <= 1.0 else int(float(score))
+        lines.append(f"    Plan - {t} ({pct}%) :e{event_idx}, {offset}, {offset + MIN_DURATION_MS}")
+        event_idx += 1
+        offset += MIN_DURATION_MS
+
+    for rd in dialog_redirects:
+        rd_label = _sanitize(rd)
+        tag = "crit" if outcome in ("Escalated", "Abandoned") else "active"
+        lines.append(f"    Execute {rd_label} :{tag}, e{event_idx}, {offset}, {offset + MIN_DURATION_MS}")
+        event_idx += 1
+        offset += MIN_DURATION_MS
+
+    lines.append("    section Bot")
+    for ms, role, content in timed:
+        if role == "assistant":
+            label = _sanitize(content)
+            lines.append(f"    {label} :done, e{event_idx}, {ms}, {ms + MIN_DURATION_MS}")
+            event_idx += 1
+
+    last_ms = timed[-1][0] + MIN_DURATION_MS * 2 if timed else 0
+    outcome_tag = "crit" if outcome in ("Escalated", "Abandoned") else "done"
+    lines.append("    section Outcome")
+    lines.append(f"    {outcome} :{outcome_tag}, e{event_idx}, {last_ms}, {last_ms + MIN_DURATION_MS}")
+
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# State
+# ---------------------------------------------------------------------------
+
+
+class RetroConversationsState(State):
+    retro_run_id: int = 0
+    run_name: str = ""
+    conversation_list: list[dict] = []
+    selected_idx: int = -1
+    selected_messages: list[dict] = []
+    # Normalized fields from activities_json — always present, typed for rx.foreach
+    sel_outcome: str = ""
+    sel_csat: str = "—"
+    sel_transcript_id: str = ""
+    sel_intent_recognition: list[dict] = []   # [{"topic": str, "confidence": str}]
+    sel_dialog_redirects: list[str] = []
+    sel_tools_used: list[str] = []
+    sel_seq_mermaid: str = ""
+    sel_gantt_mermaid: str = ""
+    sel_has_timeline: bool = False
+
+    def load_page(self) -> None:
+        run_id_str = self.router.page.params.get("run_id", "0")
+        try:
+            self.retro_run_id = int(run_id_str)
+        except (ValueError, TypeError):
+            self.retro_run_id = 0
+            return
+
+        self._reset_selection()
+
+        with rx.session() as session:
+            run = session.get(EvalRun, self.retro_run_id)
+            if not run:
+                return
+            self.run_name = run.name
+            results = session.exec(
+                select(EvalResult)
+                .where(EvalResult.eval_run_id == self.retro_run_id)
+                .order_by(EvalResult.test_case_index)
+            ).all()
+
+        rows: list[dict] = []
+        for r in results:
+            try:
+                conversation = json.loads(r.input_json)
+            except Exception:
+                conversation = []
+
+            try:
+                activities = json.loads(r.activities_json)
+            except Exception:
+                activities = []
+
+            retro_info = next((a for a in activities if a.get("type") == "retro_info"), {})
+
+            user_turns = [m for m in conversation if m.get("role") == "user"]
+            first_utterance = ""
+            if user_turns:
+                raw = user_turns[0].get("content", "")
+                first_utterance = raw[:60] + ("…" if len(raw) > 60 else "")
+
+            outcome = retro_info.get("session_outcome", "Unknown")
+            csat = retro_info.get("csat")
+            tools_used = retro_info.get("tools_used") or []
+
+            try:
+                scores = json.loads(r.scores_json)
+            except Exception:
+                scores = {}
+            topic_passed = bool(scores.get("topic_routing", {}).get("passed", False))
+
+            rows.append({
+                "result_id": r.id,
+                "idx": r.test_case_index + 1,
+                "first_utterance": first_utterance,
+                "outcome": outcome,
+                "csat": f"{csat:.1f}" if csat is not None else "—",
+                "turns": len(conversation),
+                "topic_passed": topic_passed,
+                "tools_count": len(tools_used),
+            })
+
+        self.conversation_list = rows
+
+    def _reset_selection(self) -> None:
+        self.selected_idx = -1
+        self.selected_messages = []
+        self.sel_outcome = ""
+        self.sel_csat = "—"
+        self.sel_transcript_id = ""
+        self.sel_intent_recognition = []
+        self.sel_dialog_redirects = []
+        self.sel_tools_used = []
+        self.sel_seq_mermaid = ""
+        self.sel_gantt_mermaid = ""
+        self.sel_has_timeline = False
+
+    def select_conversation(self, result_id: int) -> None:
+        for i, row in enumerate(self.conversation_list):
+            if row["result_id"] == result_id:
+                self.selected_idx = i
+                break
+
+        with rx.session() as session:
+            result = session.get(EvalResult, result_id)
+            if not result:
+                self._reset_selection()
+                return
+
+            try:
+                self.selected_messages = json.loads(result.input_json)
+            except Exception:
+                self.selected_messages = []
+
+            try:
+                activities = json.loads(result.activities_json)
+            except Exception:
+                activities = []
+
+        retro_info = next((a for a in activities if a.get("type") == "retro_info"), {})
+
+        self.sel_outcome = retro_info.get("session_outcome", "Unknown")
+        csat = retro_info.get("csat")
+        self.sel_csat = f"{csat:.1f}" if csat is not None else "—"
+        self.sel_transcript_id = retro_info.get("transcript_id", "")
+        self.sel_tools_used = retro_info.get("tools_used") or []
+        self.sel_dialog_redirects = retro_info.get("dialog_redirects") or []
+
+        # Normalize intent_recognition: [{topic, confidence}]
+        raw_intents = retro_info.get("intent_recognition") or []
+        normalized: list[dict] = []
+        for entry in raw_intents:
+            if isinstance(entry, dict):
+                score = entry.get("score", 0) or 0
+                try:
+                    pct = f"{float(score) * 100:.0f}" if float(score) <= 1.0 else f"{float(score):.0f}"
+                except Exception:
+                    pct = ""
+                normalized.append({
+                    "topic": str(entry.get("topic", "")),
+                    "confidence": pct,
+                })
+        self.sel_intent_recognition = normalized
+
+        # Build diagram texts
+        self.sel_seq_mermaid = build_sequence_mermaid(
+            self.selected_messages,
+            raw_intents,
+            retro_info.get("dialog_redirects") or [],
+            retro_info.get("tools_used") or [],
+            self.sel_outcome,
+        )
+        self.sel_gantt_mermaid = build_gantt_mermaid(
+            self.selected_messages,
+            raw_intents,
+            retro_info.get("dialog_redirects") or [],
+            self.sel_outcome,
+        )
+        self.sel_has_timeline = any(
+            m.get("timestamp") for m in self.selected_messages
+        )
+        yield rx.call_script(MERMAID_RENDER_JS)
+
+
+# ---------------------------------------------------------------------------
+# UI helpers
+# ---------------------------------------------------------------------------
+
+
+def _outcome_badge(outcome: rx.Var) -> rx.Component:
+    return rx.badge(
+        outcome,
+        color_scheme=rx.cond(
+            outcome == "Resolved",
+            "green",
+            rx.cond(
+                outcome == "Escalated",
+                "orange",
+                rx.cond(
+                    outcome == "Abandoned",
+                    "red",
+                    "gray",
+                ),
+            ),
+        ),
+        variant="soft",
+        size="1",
+    )
+
+
+def _conversation_row(r: dict) -> rx.Component:
+    return rx.box(
+        rx.hstack(
+            rx.text(
+                r["idx"].to(str),
+                size="1",
+                color="var(--gray-a8)",
+                font_family="var(--font-mono)",
+                min_width="20px",
+            ),
+            rx.vstack(
+                rx.text(r["first_utterance"], size="2", weight="medium"),
+                rx.hstack(
+                    _outcome_badge(r["outcome"]),
+                    rx.text(
+                        r["csat"],
+                        size="1",
+                        color="var(--gray-a9)",
+                        font_family="var(--font-mono)",
+                    ),
+                    rx.text(
+                        r["turns"].to(str) + " msg",
+                        size="1",
+                        color="var(--gray-a8)",
+                    ),
+                    spacing="2",
+                    align="center",
+                    flex_wrap="wrap",
+                ),
+                spacing="1",
+                align="start",
+                width="100%",
+            ),
+            spacing="2",
+            align="start",
+            width="100%",
+        ),
+        padding="10px 12px",
+        border_radius="var(--radius-2)",
+        cursor="pointer",
+        _hover={"background": "var(--accent-a2)"},
+        on_click=RetroConversationsState.select_conversation(r["result_id"]),
+        width="100%",
+    )
+
+
+def _left_panel() -> rx.Component:
+    return rx.box(
+        rx.vstack(
+            rx.hstack(
+                rx.icon("messages-square", size=14, color="var(--accent-9)"),
+                rx.text("Conversations", size="2", weight="bold"),
+                rx.badge(
+                    RetroConversationsState.conversation_list.length().to(str),
+                    variant="soft",
+                    color_scheme="gray",
+                    size="1",
+                ),
+                spacing="2",
+                align="center",
+                padding="12px 12px 8px",
+            ),
+            rx.separator(width="100%"),
+            rx.scroll_area(
+                rx.vstack(
+                    rx.foreach(
+                        RetroConversationsState.conversation_list,
+                        _conversation_row,
+                    ),
+                    spacing="1",
+                    padding="4px",
+                    width="100%",
+                ),
+                height="calc(100vh - 220px)",
+                scrollbars="vertical",
+            ),
+            spacing="0",
+            width="100%",
+        ),
+        width="280px",
+        min_width="280px",
+        border_right="1px solid var(--gray-a5)",
+        background="var(--gray-a1)",
+        flex_shrink="0",
+    )
+
+
+def _message_bubble(msg: dict) -> rx.Component:
+    return rx.cond(
+        msg["role"] == "user",
+        rx.hstack(
+            rx.spacer(),
+            rx.box(
+                rx.text(msg["content"], size="2", white_space="pre-wrap"),
+                background="var(--accent-a4)",
+                border_radius="var(--radius-3)",
+                padding="8px 12px",
+                max_width="75%",
+            ),
+            rx.box(
+                rx.icon("user", size=14, color="var(--accent-9)"),
+                padding="4px",
+                border_radius="var(--radius-full)",
+                background="var(--accent-a3)",
+                flex_shrink="0",
+            ),
+            spacing="2",
+            align="start",
+            width="100%",
+        ),
+        rx.hstack(
+            rx.box(
+                rx.icon("bot", size=14, color="var(--gray-a9)"),
+                padding="4px",
+                border_radius="var(--radius-full)",
+                background="var(--gray-a3)",
+                flex_shrink="0",
+            ),
+            rx.box(
+                rx.text(msg["content"], size="2", white_space="pre-wrap"),
+                background="var(--gray-a3)",
+                border_radius="var(--radius-3)",
+                padding="8px 12px",
+                max_width="75%",
+            ),
+            rx.spacer(),
+            spacing="2",
+            align="start",
+            width="100%",
+        ),
+    )
+
+
+def _intent_row(intent: dict) -> rx.Component:
+    return rx.hstack(
+        rx.text(intent["topic"], size="2"),
+        rx.badge(
+            intent["confidence"].to(str) + "%",
+            variant="soft",
+            color_scheme="teal",
+            size="1",
+        ),
+        spacing="2",
+        align="center",
+    )
+
+
+def _trace_card() -> rx.Component:
+    return rx.card(
+        rx.vstack(
+            rx.hstack(
+                rx.icon("activity", size=16, color="var(--accent-9)"),
+                rx.text("Execution Trace", size="3", weight="bold"),
+                spacing="2",
+                align="center",
+            ),
+            rx.separator(width="100%"),
+            # Intent Routing
+            rx.cond(
+                RetroConversationsState.sel_intent_recognition.length() > 0,
+                rx.vstack(
+                    rx.hstack(
+                        rx.icon("target", size=14, color="var(--accent-9)"),
+                        rx.text("Intent Routing", size="2", weight="bold"),
+                        spacing="2",
+                        align="center",
+                    ),
+                    rx.foreach(
+                        RetroConversationsState.sel_intent_recognition,
+                        _intent_row,
+                    ),
+                    spacing="2",
+                    align="start",
+                    width="100%",
+                ),
+            ),
+            # Dialog Redirects
+            rx.cond(
+                RetroConversationsState.sel_dialog_redirects.length() > 0,
+                rx.vstack(
+                    rx.hstack(
+                        rx.icon("arrow-right-left", size=14, color="var(--accent-9)"),
+                        rx.text("Dialog Redirects", size="2", weight="bold"),
+                        spacing="2",
+                        align="center",
+                    ),
+                    rx.foreach(
+                        RetroConversationsState.sel_dialog_redirects,
+                        lambda redirect: rx.hstack(
+                            rx.text("→", size="2", color="var(--gray-a8)"),
+                            rx.text(redirect, size="2"),
+                            spacing="1",
+                            align="center",
+                        ),
+                    ),
+                    spacing="2",
+                    align="start",
+                    width="100%",
+                ),
+            ),
+            # Tools Used
+            rx.cond(
+                RetroConversationsState.sel_tools_used.length() > 0,
+                rx.vstack(
+                    rx.hstack(
+                        rx.icon("wrench", size=14, color="var(--accent-9)"),
+                        rx.text("Tools Used", size="2", weight="bold"),
+                        spacing="2",
+                        align="center",
+                    ),
+                    rx.hstack(
+                        rx.foreach(
+                            RetroConversationsState.sel_tools_used,
+                            lambda tool: rx.badge(
+                                tool,
+                                variant="outline",
+                                size="1",
+                                color_scheme="violet",
+                            ),
+                        ),
+                        flex_wrap="wrap",
+                        spacing="1",
+                    ),
+                    spacing="2",
+                    align="start",
+                    width="100%",
+                ),
+            ),
+            # Session Outcome
+            rx.vstack(
+                rx.hstack(
+                    rx.icon("check-circle", size=14, color="var(--accent-9)"),
+                    rx.text("Session Outcome", size="2", weight="bold"),
+                    spacing="2",
+                    align="center",
+                ),
+                rx.hstack(
+                    _outcome_badge(RetroConversationsState.sel_outcome),
+                    rx.cond(
+                        RetroConversationsState.sel_csat != "—",
+                        rx.hstack(
+                            rx.text("CSAT: " + RetroConversationsState.sel_csat, size="2"),
+                            rx.icon("star", size=12, color="var(--yellow-9)"),
+                            spacing="1",
+                            align="center",
+                        ),
+                    ),
+                    spacing="3",
+                    align="center",
+                ),
+                spacing="2",
+                align="start",
+                width="100%",
+            ),
+            # Transcript ID
+            rx.vstack(
+                rx.hstack(
+                    rx.icon("hash", size=14, color="var(--accent-9)"),
+                    rx.text("Transcript ID", size="2", weight="bold"),
+                    spacing="2",
+                    align="center",
+                ),
+                rx.text(
+                    RetroConversationsState.sel_transcript_id,
+                    size="1",
+                    color="var(--gray-a9)",
+                    font_family="var(--font-mono)",
+                ),
+                spacing="1",
+                align="start",
+                width="100%",
+            ),
+            spacing="4",
+            width="100%",
+        ),
+        width="100%",
+    )
+
+
+def _sequence_flow_card() -> rx.Component:
+    return rx.card(
+        rx.vstack(
+            rx.hstack(
+                rx.icon("git-branch", size=16, color="var(--accent-9)"),
+                rx.text("Execution Flow", size="3", weight="bold"),
+                spacing="2",
+                align="center",
+            ),
+            rx.separator(width="100%"),
+            mermaid_diagram(RetroConversationsState.sel_seq_mermaid),
+            spacing="3",
+            width="100%",
+        ),
+        width="100%",
+    )
+
+
+def _gantt_card() -> rx.Component:
+    return rx.card(
+        rx.vstack(
+            rx.hstack(
+                rx.icon("gantt-chart", size=16, color="var(--accent-9)"),
+                rx.text("Execution Gantt", size="3", weight="bold"),
+                rx.cond(
+                    ~RetroConversationsState.sel_has_timeline,
+                    rx.badge(
+                        "approx. — run a new retro eval for real timestamps",
+                        size="1",
+                        color_scheme="amber",
+                    ),
+                ),
+                spacing="2",
+                align="center",
+            ),
+            rx.separator(width="100%"),
+            mermaid_diagram(RetroConversationsState.sel_gantt_mermaid),
+            spacing="3",
+            width="100%",
+        ),
+        width="100%",
+    )
+
+
+def _right_panel() -> rx.Component:
+    return rx.cond(
+        RetroConversationsState.selected_idx >= 0,
+        rx.scroll_area(
+            rx.vstack(
+                rx.card(
+                    rx.vstack(
+                        rx.hstack(
+                            rx.icon("message-square", size=16, color="var(--accent-9)"),
+                            rx.text("Conversation Thread", size="3", weight="bold"),
+                            spacing="2",
+                            align="center",
+                        ),
+                        rx.separator(width="100%"),
+                        rx.vstack(
+                            rx.foreach(
+                                RetroConversationsState.selected_messages,
+                                _message_bubble,
+                            ),
+                            spacing="3",
+                            width="100%",
+                        ),
+                        spacing="3",
+                        width="100%",
+                    ),
+                    width="100%",
+                ),
+                _trace_card(),
+                _sequence_flow_card(),
+                _gantt_card(),
+                spacing="4",
+                width="100%",
+                padding="16px",
+            ),
+            height="calc(100vh - 160px)",
+            scrollbars="vertical",
+            width="100%",
+        ),
+        rx.box(
+            rx.vstack(
+                rx.icon("message-square", size=32, color="var(--gray-a6)"),
+                rx.text(
+                    "Select a conversation to view its trace",
+                    size="3",
+                    color="var(--gray-a8)",
+                ),
+                spacing="3",
+                align="center",
+            ),
+            display="flex",
+            align_items="center",
+            justify_content="center",
+            flex="1",
+            height="calc(100vh - 160px)",
+        ),
+    )
+
+
+@rx.page(
+    route="/retro/conversations/[run_id]",
+    title="Conversation Viewer",
+    on_load=RetroConversationsState.load_page,
+)
+def retro_conversations_page() -> rx.Component:
+    return layout(
+        rx.vstack(
+            mermaid_script(),
+            rx.vstack(
+                rx.link(
+                    rx.hstack(
+                        rx.icon("arrow-left", size=16),
+                        rx.text("Transcript Extract", size="2"),
+                        spacing="1",
+                        align="center",
+                    ),
+                    href="/retro",
+                    underline="none",
+                ),
+                rx.heading(
+                    "Conversations — ",
+                    RetroConversationsState.run_name,
+                    size="6",
+                    letter_spacing="-0.03em",
+                    weight="bold",
+                ),
+                spacing="2",
+                padding_bottom="12px",
+                width="100%",
+            ),
+            rx.hstack(
+                _left_panel(),
+                _right_panel(),
+                spacing="0",
+                align="start",
+                width="100%",
+            ),
+            spacing="0",
+            width="100%",
+        ),
+    )

--- a/web/pages/retro_suggest.py
+++ b/web/pages/retro_suggest.py
@@ -1,0 +1,582 @@
+"""Dataset Builder page — turn retro eval results into a new dataset."""
+
+import json
+
+import reflex as rx
+from sqlmodel import select
+
+from web.components import empty_state, layout
+from web.models import Dataset, EvalResult, EvalRun
+from web.state import State
+
+
+class RetroSuggestState(State):
+    retro_run_id: int = 0
+    run_name: str = ""
+
+    # All deduped suggestions (lightweight, no conversation body)
+    all_suggestions: list[dict] = []
+    # Filtered view — recomputed whenever filters or selection changes
+    filtered_suggestions: list[dict] = []
+
+    # Filters
+    filter_outcome: str = "all"  # all | Resolved | Escalated | Abandoned
+    filter_turns: str = "all"    # all | single | multi
+    filter_topic: str = "all"    # all | passed | failed
+
+    # Stats (set on load)
+    total_count: int = 0
+    dedup_skipped: int = 0
+    topic_passed_count: int = 0
+    resolved_count: int = 0
+
+    # Create form
+    dataset_name: str = ""
+    create_error: str = ""
+    created_dataset_id: int = 0
+
+    @rx.var
+    def selected_count(self) -> int:
+        return sum(1 for s in self.filtered_suggestions if s.get("selected"))
+
+    @rx.var
+    def create_disabled(self) -> bool:
+        return self.selected_count == 0 or not self.dataset_name.strip()
+
+    def load_page(self) -> None:
+        run_id_str = self.router.page.params.get("run_id", "0")
+        try:
+            self.retro_run_id = int(run_id_str)
+        except (ValueError, TypeError):
+            self.retro_run_id = 0
+            return
+
+        with rx.session() as session:
+            run = session.get(EvalRun, self.retro_run_id)
+            if not run:
+                return
+            self.run_name = run.name
+            results = session.exec(
+                select(EvalResult).where(EvalResult.eval_run_id == self.retro_run_id)
+            ).all()
+
+        # Pre-pass: count occurrences per normalised first utterance
+        utterance_counts: dict[str, int] = {}
+        for r in results:
+            try:
+                conversation = json.loads(r.input_json)
+            except Exception:
+                conversation = []
+            user_turns_pre = [t for t in conversation if t.get("role") == "user"]
+            key = (user_turns_pre[0]["content"].strip().lower() if user_turns_pre else "")
+            utterance_counts[key] = utterance_counts.get(key, 0) + 1
+
+        suggestions: list[dict] = []
+        seen_utterances: set[str] = set()
+        skipped = 0
+        topic_passed = 0
+        resolved = 0
+
+        for r in results:
+            try:
+                conversation = json.loads(r.input_json)
+            except Exception:
+                conversation = []
+
+            user_turns = [t for t in conversation if t.get("role") == "user"]
+            utterance = user_turns[0]["content"] if user_turns else ""
+            utterance_key = utterance.strip().lower()
+
+            if utterance_key in seen_utterances:
+                skipped += 1
+                continue
+            seen_utterances.add(utterance_key)
+
+            try:
+                activities = json.loads(r.activities_json)
+            except Exception:
+                activities = []
+
+            retro_info = next(
+                (a for a in activities if a.get("type") == "retro_info"), {}
+            )
+            session_outcome = retro_info.get("session_outcome", "Unknown")
+            csat = retro_info.get("csat")
+            transcript_id = retro_info.get("transcript_id", "")
+
+            try:
+                scores = json.loads(r.scores_json)
+            except Exception:
+                scores = {}
+
+            topic_score_val = scores.get("topic_routing", {}).get("score", 0.0)
+            topic_pass = bool(scores.get("topic_routing", {}).get("passed", False))
+
+            if topic_pass:
+                topic_passed += 1
+            if session_outcome == "Resolved":
+                resolved += 1
+
+            user_turns_text = "\n".join(
+                f"{i + 1}. {t['content']}" for i, t in enumerate(user_turns)
+            )
+            tools_text = ", ".join(retro_info.get("tools_used", []))
+
+            suggestions.append({
+                "eval_result_index": r.test_case_index,
+                "utterance": utterance,
+                "user_turns_text": user_turns_text,
+                "tools_text": tools_text,
+                "duplicate_count": utterance_counts.get(utterance_key, 1),
+                "is_duplicate": utterance_counts.get(utterance_key, 1) > 1,
+                "num_follow_ups": len(user_turns) - 1,
+                "is_multi_turn": len(user_turns) > 1,
+                "session_outcome": session_outcome,
+                "transcript_id": transcript_id,
+                "csat": csat if csat is not None else -1.0,
+                "topic_score": round(topic_score_val * 100),
+                "topic_passed": topic_pass,
+                "selected": True,
+            })
+
+        self.all_suggestions = suggestions
+        self.total_count = len(suggestions)
+        self.dedup_skipped = skipped
+        self.topic_passed_count = topic_passed
+        self.resolved_count = resolved
+        self.dataset_name = self.run_name
+        self.filter_outcome = "all"
+        self.filter_turns = "all"
+        self.filter_topic = "all"
+        self.create_error = ""
+        self.created_dataset_id = 0
+        self._apply_filters()
+
+    def _apply_filters(self) -> None:
+        result = []
+        for s in self.all_suggestions:
+            if self.filter_outcome != "all" and s["session_outcome"] != self.filter_outcome:
+                continue
+            if self.filter_turns == "single" and s["is_multi_turn"]:
+                continue
+            if self.filter_turns == "multi" and not s["is_multi_turn"]:
+                continue
+            if self.filter_topic == "passed" and not s["topic_passed"]:
+                continue
+            if self.filter_topic == "failed" and s["topic_passed"]:
+                continue
+            result.append(s)
+        self.filtered_suggestions = result
+
+    def set_filter_outcome(self, value: str) -> None:
+        self.filter_outcome = value
+        self._apply_filters()
+
+    def set_filter_turns(self, value: str) -> None:
+        self.filter_turns = value
+        self._apply_filters()
+
+    def set_filter_topic(self, value: str) -> None:
+        self.filter_topic = value
+        self._apply_filters()
+
+    def toggle_suggestion(self, eval_result_index: int) -> None:
+        updated = []
+        for s in self.all_suggestions:
+            if s["eval_result_index"] == eval_result_index:
+                updated.append({**s, "selected": not s["selected"]})
+            else:
+                updated.append(s)
+        self.all_suggestions = updated
+        self._apply_filters()
+
+    def select_all(self) -> None:
+        filtered_indices = {s["eval_result_index"] for s in self.filtered_suggestions}
+        updated = []
+        for s in self.all_suggestions:
+            if s["eval_result_index"] in filtered_indices:
+                updated.append({**s, "selected": True})
+            else:
+                updated.append(s)
+        self.all_suggestions = updated
+        self._apply_filters()
+
+    def deselect_all(self) -> None:
+        filtered_indices = {s["eval_result_index"] for s in self.filtered_suggestions}
+        updated = []
+        for s in self.all_suggestions:
+            if s["eval_result_index"] in filtered_indices:
+                updated.append({**s, "selected": False})
+            else:
+                updated.append(s)
+        self.all_suggestions = updated
+        self._apply_filters()
+
+    def delete_suggestion(self, eval_result_index: int) -> None:
+        self.all_suggestions = [
+            s for s in self.all_suggestions if s["eval_result_index"] != eval_result_index
+        ]
+        self._apply_filters()
+
+    def set_dataset_name(self, value: str) -> None:
+        self.dataset_name = value
+
+    def create_dataset(self):  # type: ignore[return]
+        selected = [s for s in self.all_suggestions if s.get("selected")]
+        if not selected:
+            self.create_error = "No conversations selected."
+            return None
+
+        if not self.dataset_name.strip():
+            self.create_error = "Dataset name is required."
+            return None
+
+        with rx.session() as session:
+            results = session.exec(
+                select(EvalResult).where(EvalResult.eval_run_id == self.retro_run_id)
+            ).all()
+            result_map = {r.test_case_index: r for r in results}
+
+        cases = []
+        for suggestion in selected:
+            idx = suggestion["eval_result_index"]
+            r = result_map.get(idx)
+            if not r:
+                continue
+            try:
+                conversation = json.loads(r.input_json)
+            except Exception:
+                conversation = []
+
+            user_turns = [t for t in conversation if t.get("role") == "user"]
+            turns = [{"role": "user", "content": t["content"]} for t in user_turns]
+            if not turns:
+                continue
+
+            cases.append({
+                "turns": turns,
+                "expected_output": "",
+                "expected_topic": "",
+            })
+
+        if not cases:
+            self.create_error = "No valid cases to create."
+            return None
+
+        has_multi = any(s["is_multi_turn"] for s in selected)
+        eval_type = "multi_turn" if has_multi else "single_turn"
+
+        with rx.session() as session:
+            dataset = Dataset(
+                name=self.dataset_name.strip(),
+                eval_type=eval_type,
+                data_json=json.dumps(cases),
+                num_cases=len(cases),
+            )
+            session.add(dataset)
+            session.commit()
+            session.refresh(dataset)
+            new_id = dataset.id
+
+        self.created_dataset_id = new_id
+        self.create_error = ""
+        return rx.redirect(f"/datasets/{new_id}")
+
+
+# ---------------------------------------------------------------------------
+# UI helpers
+# ---------------------------------------------------------------------------
+
+
+def _outcome_badge(outcome: rx.Var) -> rx.Component:
+    return rx.badge(
+        outcome,
+        color_scheme=rx.cond(
+            outcome == "Resolved",
+            "green",
+            rx.cond(
+                outcome == "Escalated",
+                "orange",
+                rx.cond(
+                    outcome == "Abandoned",
+                    "red",
+                    "gray",
+                ),
+            ),
+        ),
+        variant="soft",
+        size="1",
+    )
+
+
+def _suggestion_row(s: dict) -> rx.Component:
+    return rx.table.row(
+        rx.table.cell(
+            rx.checkbox(checked=s["selected"]),
+            on_click=RetroSuggestState.toggle_suggestion(s["eval_result_index"]),
+            cursor="pointer",
+        ),
+        rx.table.cell(
+            rx.text(
+                s["user_turns_text"],
+                size="2",
+                white_space="pre-line",
+            ),
+        ),
+        rx.table.cell(
+            rx.cond(
+                s["is_multi_turn"],
+                rx.badge("multi", variant="soft", size="1", color_scheme="blue"),
+                rx.badge("single", variant="soft", size="1", color_scheme="gray"),
+            ),
+        ),
+        rx.table.cell(_outcome_badge(s["session_outcome"])),
+        rx.table.cell(
+            rx.text(
+                s["topic_score"].to(str) + "%",
+                size="1",
+                font_family="var(--font-mono)",
+                color=rx.cond(
+                    s["topic_passed"],
+                    "var(--green-9)",
+                    "var(--red-9)",
+                ),
+            ),
+        ),
+        rx.table.cell(
+            rx.cond(
+                s["csat"] == -1.0,
+                rx.text("—", size="1", color="var(--gray-a7)"),
+                rx.text(s["csat"].to(str), size="1", font_family="var(--font-mono)"),
+            ),
+        ),
+        rx.table.cell(
+            rx.cond(
+                s["tools_text"] != "",
+                rx.text(s["tools_text"], size="1", color="var(--violet-11)"),
+                rx.text("—", size="1", color="var(--gray-a7)"),
+            ),
+        ),
+        rx.table.cell(
+            rx.cond(
+                s["is_duplicate"],
+                rx.badge(
+                    "×" + s["duplicate_count"].to(str),
+                    variant="soft",
+                    size="1",
+                    color_scheme="amber",
+                ),
+                rx.text("—", size="1", color="var(--gray-a7)"),
+            ),
+        ),
+        rx.table.cell(
+            rx.icon_button(
+                rx.icon("trash-2", size=14),
+                size="1",
+                variant="ghost",
+                color_scheme="red",
+                on_click=RetroSuggestState.delete_suggestion(s["eval_result_index"]),
+            ),
+        ),
+    )
+
+
+def _stats_bar() -> rx.Component:
+    return rx.hstack(
+        rx.badge(
+            RetroSuggestState.total_count.to(str) + " transcripts",
+            variant="soft",
+            color_scheme="teal",
+        ),
+        rx.badge(
+            RetroSuggestState.dedup_skipped.to(str) + " duplicates removed",
+            variant="soft",
+            color_scheme="gray",
+        ),
+        rx.badge(
+            RetroSuggestState.topic_passed_count.to(str) + " passed topic routing",
+            variant="soft",
+            color_scheme="blue",
+        ),
+        rx.badge(
+            RetroSuggestState.resolved_count.to(str) + " Resolved",
+            variant="soft",
+            color_scheme="green",
+        ),
+        spacing="2",
+        flex_wrap="wrap",
+    )
+
+
+def _filter_bar() -> rx.Component:
+    return rx.hstack(
+        rx.vstack(
+            rx.text("Outcome", size="1", weight="medium", color="var(--gray-a9)"),
+            rx.select(
+                ["all", "Resolved", "Escalated", "Abandoned"],
+                value=RetroSuggestState.filter_outcome,
+                on_change=RetroSuggestState.set_filter_outcome,
+                size="1",
+            ),
+            spacing="1",
+        ),
+        rx.vstack(
+            rx.text("Turns", size="1", weight="medium", color="var(--gray-a9)"),
+            rx.select(
+                ["all", "single", "multi"],
+                value=RetroSuggestState.filter_turns,
+                on_change=RetroSuggestState.set_filter_turns,
+                size="1",
+            ),
+            spacing="1",
+        ),
+        rx.vstack(
+            rx.text("Topic Routing", size="1", weight="medium", color="var(--gray-a9)"),
+            rx.select(
+                ["all", "passed", "failed"],
+                value=RetroSuggestState.filter_topic,
+                on_change=RetroSuggestState.set_filter_topic,
+                size="1",
+            ),
+            spacing="1",
+        ),
+        rx.spacer(),
+        rx.button(
+            "Select All",
+            variant="soft",
+            size="1",
+            on_click=RetroSuggestState.select_all,
+        ),
+        rx.button(
+            "Deselect All",
+            variant="soft",
+            size="1",
+            color_scheme="gray",
+            on_click=RetroSuggestState.deselect_all,
+        ),
+        align="end",
+        spacing="3",
+        width="100%",
+        padding_y="8px",
+    )
+
+
+def _suggestion_table() -> rx.Component:
+    return rx.cond(
+        RetroSuggestState.all_suggestions.length() > 0,
+        rx.cond(
+            RetroSuggestState.filtered_suggestions.length() > 0,
+            rx.table.root(
+                rx.table.header(
+                    rx.table.row(
+                        rx.table.column_header_cell(""),
+                        rx.table.column_header_cell("Utterance"),
+                        rx.table.column_header_cell("Turns"),
+                        rx.table.column_header_cell("Outcome"),
+                        rx.table.column_header_cell("Topic %"),
+                        rx.table.column_header_cell("CSAT"),
+                        rx.table.column_header_cell("Tools"),
+                        rx.table.column_header_cell("Seen"),
+                        rx.table.column_header_cell(""),
+                    ),
+                ),
+                rx.table.body(
+                    rx.foreach(
+                        RetroSuggestState.filtered_suggestions,
+                        _suggestion_row,
+                    ),
+                ),
+                width="100%",
+            ),
+            empty_state("No conversations match the current filters.", "filter"),
+        ),
+        empty_state("No eval results found for this run.", "inbox"),
+    )
+
+
+def _create_card() -> rx.Component:
+    return rx.card(
+        rx.vstack(
+            rx.hstack(
+                rx.icon("database", size=16, color="var(--accent-9)"),
+                rx.text("Create Dataset", size="3", weight="bold"),
+                spacing="2",
+                align="center",
+            ),
+            rx.vstack(
+                rx.text("Dataset Name", size="2", weight="medium"),
+                rx.input(
+                    value=RetroSuggestState.dataset_name,
+                    on_change=RetroSuggestState.set_dataset_name,
+                    placeholder="Dataset name...",
+                    width="100%",
+                ),
+                spacing="1",
+                width="100%",
+            ),
+            rx.text(
+                RetroSuggestState.selected_count.to(str) + " conversations selected",
+                size="2",
+                color="var(--gray-a9)",
+            ),
+            rx.cond(
+                RetroSuggestState.create_error != "",
+                rx.callout(
+                    RetroSuggestState.create_error,
+                    icon="triangle_alert",
+                    color_scheme="red",
+                    width="100%",
+                ),
+            ),
+            rx.button(
+                rx.icon("database", size=14),
+                "Create Dataset",
+                on_click=RetroSuggestState.create_dataset,
+                disabled=RetroSuggestState.create_disabled,
+                size="2",
+            ),
+            spacing="3",
+            width="100%",
+        ),
+        width="100%",
+    )
+
+
+@rx.page(
+    route="/retro/suggest/[run_id]",
+    title="Dataset Builder",
+    on_load=RetroSuggestState.load_page,
+)
+def retro_suggest_page() -> rx.Component:
+    return layout(
+        rx.vstack(
+            rx.vstack(
+                rx.link(
+                    rx.hstack(
+                        rx.icon("arrow-left", size=16),
+                        rx.text("Transcript Extract", size="2"),
+                        spacing="1",
+                        align="center",
+                    ),
+                    href="/retro",
+                    underline="none",
+                ),
+                rx.heading(
+                    "Build Dataset — ",
+                    RetroSuggestState.run_name,
+                    size="6",
+                    letter_spacing="-0.03em",
+                    weight="bold",
+                ),
+                _stats_bar(),
+                spacing="2",
+                padding_bottom="16px",
+                width="100%",
+            ),
+            _filter_bar(),
+            _suggestion_table(),
+            _create_card(),
+            spacing="4",
+            width="100%",
+        ),
+    )

--- a/web/pages/run_detail.py
+++ b/web/pages/run_detail.py
@@ -54,6 +54,7 @@ class ResultRow(rx.Base):
     scores_color: str = "gray"
     conv_turns: list[ConvTurn] = []
     tool_lines: list[ToolLine] = []
+    has_error: bool = False
 
 
 class RunDetailState(State):
@@ -187,6 +188,15 @@ class RunDetailState(State):
                                 line += f"  args: {args}"
                             tool_lines.append(ToolLine(icon="link", text=line, color="purple"))
 
+                        elif atype == "retro_info":
+                            outcome = a.get("session_outcome", "Unknown")
+                            csat = a.get("csat")
+                            length = a.get("conversation_length")
+                            csat_str = f"  |  CSAT: {csat:.1f}" if csat is not None else ""
+                            length_str = f"  |  Turns: {length}" if length is not None else ""
+                            line = f"Outcome: {outcome}{csat_str}{length_str}"
+                            tool_lines.append(ToolLine(icon="history", text=line, color="teal"))
+
                         else:
                             line = f"[{atype}] {aname}"
                             if value:
@@ -208,6 +218,7 @@ class RunDetailState(State):
                     scores_color=overall_color,
                     conv_turns=conv_turns,
                     tool_lines=tool_lines,
+                    has_error=(r.actual_output or "").startswith("Error:"),
                 ))
 
     def load_run(self) -> None:
@@ -461,6 +472,16 @@ def _tool_line(item: rx.Var) -> rx.Component:
 def _expanded_content(r: rx.Var) -> rx.Component:
     return rx.vstack(
         rx.separator(margin_top="4px", margin_bottom="8px"),
+        # Error callout (shown when actual_output starts with "Error:")
+        rx.cond(
+            r["has_error"],
+            rx.callout(
+                r["actual_output"].to(str),
+                icon="triangle_alert",
+                color_scheme="red",
+                width="100%",
+            ),
+        ),
         # Conversation
         rx.cond(
             r["conv_turns"].length() > 0,

--- a/web/pages/run_detail.py
+++ b/web/pages/run_detail.py
@@ -150,8 +150,6 @@ class RunDetailState(State):
                     }
                 )
 
-            self.expanded_result = -1
-
     def load_run(self) -> None:
         run_id_str = self.router.page.params.get("run_id", "0")
         try:
@@ -160,6 +158,7 @@ class RunDetailState(State):
             return
 
         self._load_run_data(run_id)
+        self.expanded_result = -1  # reset on initial page load only
 
         if self.run.get("status") == "running" and not self.is_live:
             self.is_live = True

--- a/web/pages/run_detail.py
+++ b/web/pages/run_detail.py
@@ -20,9 +20,45 @@ def _color_for_score(val: float) -> str:
     return "red"
 
 
+class ScoreItem(rx.Base):
+    name: str = ""
+    raw: str = ""
+    val_pct: str = ""
+    val_text: str = ""
+    color: str = "gray"
+    reason: str = ""
+    bar_width: str = "0%"
+
+
+class ConvTurn(rx.Base):
+    role: str = ""
+    content: str = ""
+    is_user: bool = False
+
+
+class ToolLine(rx.Base):
+    icon: str = "zap"
+    text: str = ""
+    color: str = "gray"
+
+
+class ResultRow(rx.Base):
+    index: int = 0
+    num: str = ""
+    passed: bool = False
+    duration: str = ""
+    actual_output: str = ""
+    expected_output: str = ""
+    scores_summary: str = ""
+    score_items: list[ScoreItem] = []
+    scores_color: str = "gray"
+    conv_turns: list[ConvTurn] = []
+    tool_lines: list[ToolLine] = []
+
+
 class RunDetailState(State):
     run: dict = {}
-    results: list[dict] = []
+    results: list[ResultRow] = []
     expanded_result: int = -1
     dataset_name: str = ""
     is_live: bool = False
@@ -69,22 +105,22 @@ class RunDetailState(State):
                 scores_raw = json.loads(r.scores_json) if r.scores_json else {}
 
                 # Build structured score items for visual rendering
-                score_items = []
+                score_items: list[ScoreItem] = []
                 overall_color = "gray"
                 for mname, data in scores_raw.items():
                     val = data.get("score", 0) if isinstance(data, dict) else 0
                     reason = data.get("reason", "") if isinstance(data, dict) else ""
                     color = _color_for_score(val)
                     pct = round(val * 100)
-                    score_items.append({
-                        "name": mname.replace("_", " ").title(),
-                        "raw": mname,
-                        "val_pct": str(pct),
-                        "val_text": f"{val:.0%}",
-                        "color": color,
-                        "reason": reason,
-                        "bar_width": f"{pct}%",
-                    })
+                    score_items.append(ScoreItem(
+                        name=mname.replace("_", " ").title(),
+                        raw=mname,
+                        val_pct=str(pct),
+                        val_text=f"{val:.0%}",
+                        color=color,
+                        reason=reason,
+                        bar_width=f"{pct}%",
+                    ))
                     if color == "red":
                         overall_color = "red"
                     elif color == "yellow" and overall_color != "red":
@@ -93,7 +129,7 @@ class RunDetailState(State):
                         overall_color = "green"
 
                 scores_summary = " · ".join(
-                    f"{it['raw']}: {it['val_text']}"
+                    f"{it.raw}: {it.val_text}"
                     for it in score_items
                 )
 
@@ -101,14 +137,14 @@ class RunDetailState(State):
                 input_turns = (
                     json.loads(r.input_json) if r.input_json else []
                 )
-                conv_turns = []
+                conv_turns: list[ConvTurn] = []
                 for t in input_turns:
                     role = t.get("role", "user")
-                    conv_turns.append({
-                        "role": "User" if role == "user" else "Assistant",
-                        "content": t.get("content", ""),
-                        "is_user": role == "user",
-                    })
+                    conv_turns.append(ConvTurn(
+                        role="User" if role == "user" else "Assistant",
+                        content=t.get("content", ""),
+                        is_user=role == "user",
+                    ))
 
                 raw_activities = json.loads(r.activities_json) if r.activities_json else []
                 tool_activities = [
@@ -116,7 +152,7 @@ class RunDetailState(State):
                     for a in raw_activities
                     if a.get("type") not in ("message", "end_of_conversation", "typing", None)
                 ]
-                tool_lines = []
+                tool_lines: list[ToolLine] = []
                 if tool_activities:
                     for a in tool_activities:
                         atype = a.get("type", "?")
@@ -134,14 +170,14 @@ class RunDetailState(State):
                             line = f"Plan · Topics: {', '.join(topics)}"
                             if kinds:
                                 line += f"  |  Tools: {', '.join(kinds)}"
-                            tool_lines.append({"icon": "map", "text": line, "color": "blue"})
+                            tool_lines.append(ToolLine(icon="map", text=line, color="blue"))
 
                         elif aname == "DynamicPlanStepTriggered":
                             topic = value.get("taskDialogId", "").rsplit(".", 1)[-1]
                             state = value.get("state", "?")
                             step_type = value.get("type", "?")
                             line = f"Step · {topic} [{step_type}] state: {state}"
-                            tool_lines.append({"icon": "play", "text": line, "color": "teal"})
+                            tool_lines.append(ToolLine(icon="play", text=line, color="teal"))
 
                         elif aname == "DynamicPlanStepBindUpdate":
                             topic = value.get("taskDialogId", "").rsplit(".", 1)[-1]
@@ -149,30 +185,30 @@ class RunDetailState(State):
                             line = f"Bind · {topic}"
                             if args:
                                 line += f"  args: {args}"
-                            tool_lines.append({"icon": "link", "text": line, "color": "purple"})
+                            tool_lines.append(ToolLine(icon="link", text=line, color="purple"))
 
                         else:
                             line = f"[{atype}] {aname}"
                             if value:
                                 line += f"  →  {value}"
-                            tool_lines.append({"icon": "zap", "text": line, "color": "gray"})
+                            tool_lines.append(ToolLine(icon="zap", text=line, color="gray"))
 
                 if not tool_lines:
-                    tool_lines.append({"icon": "minus", "text": "No tool activity captured", "color": "gray"})
+                    tool_lines.append(ToolLine(icon="minus", text="No tool activity captured", color="gray"))
 
-                self.results.append({
-                    "index": r.test_case_index,
-                    "num": str(r.test_case_index + 1),
-                    "passed": r.passed,
-                    "duration": f"{r.duration_seconds:.1f}s",
-                    "actual_output": r.actual_output or "",
-                    "expected_output": r.expected_output or "",
-                    "scores_summary": scores_summary,
-                    "score_items": score_items,
-                    "scores_color": overall_color,
-                    "conv_turns": conv_turns,
-                    "tool_lines": tool_lines,
-                })
+                self.results.append(ResultRow(
+                    index=r.test_case_index,
+                    num=str(r.test_case_index + 1),
+                    passed=r.passed,
+                    duration=f"{r.duration_seconds:.1f}s",
+                    actual_output=r.actual_output or "",
+                    expected_output=r.expected_output or "",
+                    scores_summary=scores_summary,
+                    score_items=score_items,
+                    scores_color=overall_color,
+                    conv_turns=conv_turns,
+                    tool_lines=tool_lines,
+                ))
 
     def load_run(self) -> None:
         run_id_str = self.router.page.params.get("run_id", "0")
@@ -431,7 +467,7 @@ def _expanded_content(r: rx.Var) -> rx.Component:
             rx.vstack(
                 rx.hstack(
                     rx.icon("message-circle", size=14, color="var(--accent-9)"),
-                    rx.text("Conversation", size="2", weight="semibold"),
+                    rx.text("Conversation", size="2", weight="bold"),
                     spacing="2",
                     align="center",
                 ),
@@ -509,7 +545,7 @@ def _expanded_content(r: rx.Var) -> rx.Component:
             rx.vstack(
                 rx.hstack(
                     rx.icon("bar-chart-2", size=14, color="var(--accent-9)"),
-                    rx.text("Metric Scores", size="2", weight="semibold"),
+                    rx.text("Metric Scores", size="2", weight="bold"),
                     spacing="2",
                     align="center",
                 ),
@@ -530,7 +566,7 @@ def _expanded_content(r: rx.Var) -> rx.Component:
         rx.vstack(
             rx.hstack(
                 rx.icon("zap", size=14, color="var(--accent-9)"),
-                rx.text("Tool Activity", size="2", weight="semibold"),
+                rx.text("Tool Activity", size="2", weight="bold"),
                 spacing="2",
                 align="center",
             ),
@@ -779,7 +815,7 @@ def _results_section() -> rx.Component:
                 rx.text(
                     "Results",
                     size="3",
-                    weight="semibold",
+                    weight="bold",
                 ),
                 rx.badge(
                     RunDetailState.results.length().to(str),

--- a/web/pages/run_detail.py
+++ b/web/pages/run_detail.py
@@ -1,5 +1,6 @@
 """Run detail page — full results view with expandable rows."""
 
+import asyncio
 import json
 from datetime import datetime
 
@@ -24,14 +25,10 @@ class RunDetailState(State):
     results: list[dict] = []
     expanded_result: int = -1
     dataset_name: str = ""
+    is_live: bool = False
 
-    def load_run(self) -> None:
-        run_id_str = self.router.page.params.get("run_id", "0")
-        try:
-            run_id = int(run_id_str)
-        except (ValueError, TypeError):
-            return
-
+    def _load_run_data(self, run_id: int) -> None:
+        """Load run + results from DB into state. Does not touch is_live."""
         with rx.session() as session:
             run_obj = session.get(EvalRun, run_id)
             if not run_obj:
@@ -44,13 +41,8 @@ class RunDetailState(State):
                 "id": run_obj.id,
                 "name": run_obj.name,
                 "status": run_obj.status,
-                "avg_score": (
-                    f"{run_obj.avg_score:.1%}"
-                    if run_obj.avg_score > 0 else "—"
-                ),
-                "progress": (
-                    f"{run_obj.completed_cases}/{run_obj.total_cases}"
-                ),
+                "avg_score": (f"{run_obj.avg_score:.1%}" if run_obj.avg_score > 0 else "—"),
+                "progress": (f"{run_obj.completed_cases}/{run_obj.total_cases}"),
                 "error": run_obj.error,
                 "created": run_obj.created_at.strftime("%d-%m-%Y %H:%M"),
             }
@@ -63,23 +55,14 @@ class RunDetailState(State):
 
             self.results = []
             for r in result_rows:
-                scores_raw = (
-                    json.loads(r.scores_json) if r.scores_json else {}
-                )
+                scores_raw = json.loads(r.scores_json) if r.scores_json else {}
 
-                # Pre-format scores summary: "metric: 85%" badges
                 score_parts = []
                 score_detail_lines = []
                 overall_color = "gray"
                 for mname, data in scores_raw.items():
-                    val = (
-                        data.get("score", 0)
-                        if isinstance(data, dict) else 0
-                    )
-                    reason = (
-                        data.get("reason", "")
-                        if isinstance(data, dict) else ""
-                    )
+                    val = data.get("score", 0) if isinstance(data, dict) else 0
+                    reason = data.get("reason", "") if isinstance(data, dict) else ""
                     color = _color_for_score(val)
                     score_parts.append(f"{mname}: {val:.0%}")
                     detail = f"[{color}] {mname}: {val:.0%}"
@@ -96,28 +79,18 @@ class RunDetailState(State):
                 scores_summary = " | ".join(score_parts)
                 scores_detail = "\n\n".join(score_detail_lines)
 
-                # Pre-format conversation
-                input_turns = (
-                    json.loads(r.input_json) if r.input_json else []
-                )
+                input_turns = json.loads(r.input_json) if r.input_json else []
                 conv_lines = []
                 for t in input_turns:
-                    role = (
-                        "User" if t.get("role") == "user"
-                        else "Assistant"
-                    )
+                    role = "User" if t.get("role") == "user" else "Assistant"
                     conv_lines.append(f"{role}: {t.get('content', '')}")
                 conversation_text = "\n\n".join(conv_lines)
 
-                # Parse tool/non-message activities
-                raw_activities = (
-                    json.loads(r.activities_json) if r.activities_json else []
-                )
+                raw_activities = json.loads(r.activities_json) if r.activities_json else []
                 tool_activities = [
-                    a for a in raw_activities
-                    if a.get("type") not in (
-                        "message", "end_of_conversation", "typing", None
-                    )
+                    a
+                    for a in raw_activities
+                    if a.get("type") not in ("message", "end_of_conversation", "typing", None)
                 ]
                 if tool_activities:
                     tool_lines = []
@@ -161,21 +134,47 @@ class RunDetailState(State):
                 else:
                     tool_calls_text = "No tool activity captured"
 
-                self.results.append({
-                    "index": r.test_case_index,
-                    "num": str(r.test_case_index + 1),
-                    "passed": r.passed,
-                    "duration": f"{r.duration_seconds:.1f}s",
-                    "actual_output": r.actual_output,
-                    "expected_output": r.expected_output,
-                    "scores_summary": scores_summary,
-                    "scores_detail": scores_detail,
-                    "scores_color": overall_color,
-                    "conversation_text": conversation_text,
-                    "tool_calls_text": tool_calls_text,
-                })
+                self.results.append(
+                    {
+                        "index": r.test_case_index,
+                        "num": str(r.test_case_index + 1),
+                        "passed": r.passed,
+                        "duration": f"{r.duration_seconds:.1f}s",
+                        "actual_output": r.actual_output,
+                        "expected_output": r.expected_output,
+                        "scores_summary": scores_summary,
+                        "scores_detail": scores_detail,
+                        "scores_color": overall_color,
+                        "conversation_text": conversation_text,
+                        "tool_calls_text": tool_calls_text,
+                    }
+                )
 
-        self.expanded_result = -1
+            self.expanded_result = -1
+
+    def load_run(self) -> None:
+        run_id_str = self.router.page.params.get("run_id", "0")
+        try:
+            run_id = int(run_id_str)
+        except (ValueError, TypeError):
+            return
+
+        self._load_run_data(run_id)
+
+        if self.run.get("status") == "running" and not self.is_live:
+            self.is_live = True
+            return RunDetailState.live_poll(run_id)
+
+    @rx.event(background=True)
+    async def live_poll(self, run_id: int) -> None:
+        """Poll DB every 3s while run is still executing."""
+        while True:
+            await asyncio.sleep(3)
+            async with self:
+                self._load_run_data(run_id)
+                if self.run.get("status") not in ("running", "pending"):
+                    self.is_live = False
+                    break
 
     def toggle_result(self, index: int) -> None:
         if self.expanded_result == index:
@@ -183,7 +182,9 @@ class RunDetailState(State):
         else:
             self.expanded_result = index
 
-    def rerun(self) -> rx.Component:
+    def rerun(self):
+        from web.pages.runs import RunState
+
         run_id_str = self.router.page.params.get("run_id", "0")
         try:
             run_id = int(run_id_str)
@@ -198,8 +199,9 @@ class RunDetailState(State):
             if not dataset:
                 return
 
+            base_name = original.name.split(" (rerun)")[0]
             run = EvalRun(
-                name=f"{original.name} (rerun)",
+                name=f"{base_name} (rerun)",
                 dataset_id=original.dataset_id,
                 status="pending",
                 metrics_json=original.metrics_json,
@@ -212,7 +214,8 @@ class RunDetailState(State):
             session.refresh(run)
             new_run_id = run.id
 
-        return rx.redirect(f"/runs/{new_run_id}")
+        yield rx.redirect(f"/runs/{new_run_id}")
+        yield RunState.execute_run(new_run_id)
 
     def export_results(self) -> rx.Component:
         export_data = {
@@ -221,9 +224,7 @@ class RunDetailState(State):
         }
         return rx.download(
             data=json.dumps(export_data, indent=2, default=str),
-            filename=(
-                f"run_{self.run.get('id', 'unknown')}_results.json"
-            ),
+            filename=(f"run_{self.run.get('id', 'unknown')}_results.json"),
         )
 
 
@@ -376,9 +377,7 @@ def _result_row(r: rx.Var) -> rx.Component:
                     ),
                     variant="ghost",
                     size="1",
-                    on_click=RunDetailState.toggle_result(
-                        r["index"]
-                    ),
+                    on_click=RunDetailState.toggle_result(r["index"]),
                 ),
                 align="center",
                 width="100%",
@@ -410,6 +409,10 @@ def _header_section() -> rx.Component:
         rx.hstack(
             rx.heading(RunDetailState.run["name"], size="6"),
             status_badge(RunDetailState.run["status"]),
+            rx.cond(
+                RunDetailState.is_live,
+                rx.badge("● Live", color_scheme="teal", variant="soft", size="1"),
+            ),
             rx.spacer(),
             rx.button(
                 rx.icon("rotate-cw", size=14),

--- a/web/pages/runs.py
+++ b/web/pages/runs.py
@@ -178,6 +178,14 @@ class RunState(State):
             "name": run_b.name,
             "pass_rate": f"{pass_rate(results_b):.0%}",
         }
+        def delta_str(sa: float, sb: float) -> str:
+            d = sb - sa
+            if d > 0:
+                return f"↑ {abs(d):.0%}"
+            if d < 0:
+                return f"↓ {abs(d):.0%}"
+            return "—"
+
         self.compare_metrics = [
             {
                 "name": m,
@@ -185,7 +193,7 @@ class RunState(State):
                 "b_score": f"{scores_b.get(m, 0):.0%}",
                 "delta_up": scores_b.get(m, 0) > scores_a.get(m, 0),
                 "delta_down": scores_b.get(m, 0) < scores_a.get(m, 0),
-                "delta_display": f"{abs(scores_b.get(m, 0) - scores_a.get(m, 0)):.0%}",
+                "delta_str": delta_str(scores_a.get(m, 0), scores_b.get(m, 0)),
             }
             for m in all_metrics
         ]
@@ -594,18 +602,10 @@ def compare_dialog() -> rx.Component:
                         rx.text(m["b_score"], size="2", flex="1"),
                         rx.cond(
                             m["delta_up"],
-                            rx.badge(
-                                "↑ " + m["delta_display"],
-                                color_scheme="green",
-                                size="1",
-                            ),
+                            rx.badge(m["delta_str"], color_scheme="green", size="1"),
                             rx.cond(
                                 m["delta_down"],
-                                rx.badge(
-                                    "↓ " + m["delta_display"],
-                                    color_scheme="red",
-                                    size="1",
-                                ),
+                                rx.badge(m["delta_str"], color_scheme="red", size="1"),
                                 rx.badge("—", color_scheme="gray", size="1"),
                             ),
                         ),

--- a/web/pages/runs.py
+++ b/web/pages/runs.py
@@ -46,11 +46,14 @@ class RunState(State):
     max_concurrent: int = 3
     create_error: str = ""
 
+    # Compare mode
+    compare_selected: list[int] = []
+    show_compare: bool = False
+    compare_data: dict = {}
+
     def load_runs(self) -> None:
         with rx.session() as session:
-            rows = session.exec(
-                select(EvalRun).order_by(EvalRun.created_at.desc())
-            ).all()
+            rows = session.exec(select(EvalRun).order_by(EvalRun.created_at.desc())).all()
         self.runs = [
             {
                 "id": r.id,
@@ -59,8 +62,7 @@ class RunState(State):
                 "avg_score": f"{r.avg_score:.1%}" if r.avg_score > 0 else "—",
                 "progress": f"{r.completed_cases}/{r.total_cases}",
                 "progress_pct": (
-                    round(r.completed_cases / r.total_cases * 100)
-                    if r.total_cases > 0 else 0
+                    round(r.completed_cases / r.total_cases * 100) if r.total_cases > 0 else 0
                 ),
                 "error": r.error,
                 "created": r.created_at.strftime("%d-%m-%Y %H:%M"),
@@ -70,16 +72,12 @@ class RunState(State):
 
         # Load datasets for the select dropdown
         with rx.session() as ds_session:
-            datasets = ds_session.exec(
-                select(Dataset).order_by(Dataset.name)
-            ).all()
+            datasets = ds_session.exec(select(Dataset).order_by(Dataset.name)).all()
             self.dataset_options = [
-                f"{d.name} ({d.num_cases} cases, {d.eval_type})"
-                for d in datasets
+                f"{d.name} ({d.num_cases} cases, {d.eval_type})" for d in datasets
             ]
             self.dataset_id_map = {
-                f"{d.name} ({d.num_cases} cases, {d.eval_type})": d.id
-                for d in datasets
+                f"{d.name} ({d.num_cases} cases, {d.eval_type})": d.id for d in datasets
             }
 
     def open_create_dialog(self) -> None:
@@ -119,11 +117,85 @@ class RunState(State):
         except ValueError:
             self.max_concurrent = 3
 
-    def toggle_metric(self, metric: str) -> None:
-        if metric in self.selected_metrics:
-            self.selected_metrics = [m for m in self.selected_metrics if m != metric]
-        else:
+    def set_metric(self, checked: bool, metric: str) -> None:
+        if checked and metric not in self.selected_metrics:
             self.selected_metrics = self.selected_metrics + [metric]
+        elif not checked and metric in self.selected_metrics:
+            self.selected_metrics = [m for m in self.selected_metrics if m != metric]
+
+    def toggle_compare(self, run_id: int) -> None:
+        if run_id in self.compare_selected:
+            self.compare_selected = [r for r in self.compare_selected if r != run_id]
+        elif len(self.compare_selected) >= 2:
+            self.compare_selected = [self.compare_selected[1], run_id]
+        else:
+            self.compare_selected = self.compare_selected + [run_id]
+
+    def load_compare_data(self) -> None:
+        if len(self.compare_selected) != 2:
+            return
+
+        run_id_a, run_id_b = self.compare_selected[0], self.compare_selected[1]
+
+        with rx.session() as session:
+            run_a = session.get(EvalRun, run_id_a)
+            run_b = session.get(EvalRun, run_id_b)
+            if not run_a or not run_b:
+                return
+
+            results_a = session.exec(
+                select(EvalResult).where(EvalResult.eval_run_id == run_id_a)
+            ).all()
+            results_b = session.exec(
+                select(EvalResult).where(EvalResult.eval_run_id == run_id_b)
+            ).all()
+
+        def avg_scores(results):
+            totals: dict[str, list[float]] = {}
+            for r in results:
+                scores = json.loads(r.scores_json) if r.scores_json else {}
+                for mname, data in scores.items():
+                    if isinstance(data, dict):
+                        totals.setdefault(mname, []).append(data.get("score", 0))
+            return {m: sum(v) / len(v) for m, v in totals.items()}
+
+        def pass_rate(results):
+            if not results:
+                return 0.0
+            return sum(1 for r in results if r.passed) / len(results)
+
+        scores_a = avg_scores(results_a)
+        scores_b = avg_scores(results_b)
+        all_metrics = sorted(set(scores_a) | set(scores_b))
+
+        self.compare_data = {
+            "run_a": {
+                "id": run_a.id,
+                "name": run_a.name,
+                "pass_rate": f"{pass_rate(results_a):.0%}",
+            },
+            "run_b": {
+                "id": run_b.id,
+                "name": run_b.name,
+                "pass_rate": f"{pass_rate(results_b):.0%}",
+            },
+            "metrics": [
+                {
+                    "name": m,
+                    "a_score": scores_a.get(m, 0),
+                    "b_score": scores_b.get(m, 0),
+                    "delta": scores_b.get(m, 0) - scores_a.get(m, 0),
+                }
+                for m in all_metrics
+            ],
+        }
+
+    def open_compare(self) -> None:
+        self.load_compare_data()
+        self.show_compare = True
+
+    def close_compare(self) -> None:
+        self.show_compare = False
 
     def rerun(self, run_id: int) -> None:
         with rx.session() as session:
@@ -134,8 +206,9 @@ class RunState(State):
             if not dataset:
                 return
 
+            base_name = original.name.split(" (rerun)")[0]
             run = EvalRun(
-                name=f"{original.name} (rerun)",
+                name=f"{base_name} (rerun)",
                 dataset_id=original.dataset_id,
                 status="pending",
                 metrics_json=original.metrics_json,
@@ -173,11 +246,13 @@ class RunState(State):
                 dataset_id=self.selected_dataset_id,
                 status="pending",
                 metrics_json=json.dumps(self.selected_metrics),
-                config_json=json.dumps({
-                    "threshold": self.threshold,
-                    "delay_seconds": self.delay_seconds,
-                    "max_concurrent": self.max_concurrent,
-                }),
+                config_json=json.dumps(
+                    {
+                        "threshold": self.threshold,
+                        "delay_seconds": self.delay_seconds,
+                        "max_concurrent": self.max_concurrent,
+                    }
+                ),
                 total_cases=dataset.num_cases,
                 created_at=datetime.utcnow(),
             )
@@ -252,7 +327,8 @@ class RunState(State):
 
                     avg_case_score = (
                         sum(s.get("score", 0) for s in scores.values()) / len(scores)
-                        if scores else 0
+                        if scores
+                        else 0
                     )
                     passed = avg_case_score >= threshold
 
@@ -338,7 +414,7 @@ def create_run_dialog() -> rx.Component:
                             rx.checkbox(
                                 metric.replace("_", " ").title(),
                                 checked=RunState.selected_metrics.contains(metric),
-                                on_change=lambda _val, m=metric: RunState.toggle_metric(m),
+                                on_change=lambda val, m=metric: RunState.set_metric(val, m),
                             ),
                             spacing="2",
                         )
@@ -416,11 +492,11 @@ def create_run_dialog() -> rx.Component:
     )
 
 
-
 def runs_table() -> rx.Component:
     return rx.table.root(
         rx.table.header(
             rx.table.row(
+                rx.table.column_header_cell(""),  # checkbox column
                 rx.table.column_header_cell("Name"),
                 rx.table.column_header_cell("Status"),
                 rx.table.column_header_cell("Progress"),
@@ -433,6 +509,12 @@ def runs_table() -> rx.Component:
             rx.foreach(
                 RunState.runs,
                 lambda r: rx.table.row(
+                    rx.table.cell(
+                        rx.checkbox(
+                            checked=RunState.compare_selected.contains(r["id"]),
+                            on_change=lambda _: RunState.toggle_compare(r["id"]),
+                        ),
+                    ),
                     rx.table.cell(rx.text(r["name"], weight="medium")),
                     rx.table.cell(status_badge(r["status"])),
                     rx.table.cell(
@@ -470,6 +552,108 @@ def runs_table() -> rx.Component:
     )
 
 
+def compare_dialog() -> rx.Component:
+    return rx.dialog.root(
+        rx.dialog.content(
+            rx.dialog.title(
+                rx.hstack(
+                    rx.text("Run Comparison"),
+                    rx.spacer(),
+                    rx.dialog.close(
+                        rx.button(rx.icon("x", size=14), variant="ghost", size="1"),
+                    ),
+                ),
+            ),
+            rx.vstack(
+                # Run names header
+                rx.hstack(
+                    rx.text("Metric", weight="medium", width="160px"),
+                    rx.text(
+                        RunState.compare_data["run_a"]["name"],
+                        weight="medium",
+                        flex="1",
+                        color_scheme="blue",
+                    ),
+                    rx.text(
+                        RunState.compare_data["run_b"]["name"],
+                        weight="medium",
+                        flex="1",
+                        color_scheme="teal",
+                    ),
+                    rx.text("Delta", weight="medium", width="80px"),
+                    width="100%",
+                    spacing="2",
+                ),
+                rx.separator(width="100%"),
+                # Metric rows
+                rx.foreach(
+                    RunState.compare_data["metrics"],
+                    lambda m: rx.hstack(
+                        rx.text(m["name"].to(str), size="2", width="160px"),
+                        rx.text(
+                            (m["a_score"] * 100).to(int).to(str) + "%",
+                            size="2",
+                            flex="1",
+                        ),
+                        rx.text(
+                            (m["b_score"] * 100).to(int).to(str) + "%",
+                            size="2",
+                            flex="1",
+                        ),
+                        rx.cond(
+                            m["delta"] > 0,
+                            rx.badge(
+                                "↑ " + (m["delta"] * 100).to(int).to(str) + "%",
+                                color_scheme="green",
+                                size="1",
+                            ),
+                            rx.cond(
+                                m["delta"] < 0,
+                                rx.badge(
+                                    "↓ " + (m["delta"] * 100).to(int).to(str) + "%",
+                                    color_scheme="red",
+                                    size="1",
+                                ),
+                                rx.badge("—", color_scheme="gray", size="1"),
+                            ),
+                        ),
+                        width="100%",
+                        spacing="2",
+                        align="center",
+                    ),
+                ),
+                rx.separator(width="100%"),
+                # Pass rate row
+                rx.hstack(
+                    rx.text("Pass Rate", size="2", weight="medium", width="160px"),
+                    rx.text(
+                        RunState.compare_data["run_a"]["pass_rate"],
+                        size="2",
+                        flex="1",
+                    ),
+                    rx.text(
+                        RunState.compare_data["run_b"]["pass_rate"],
+                        size="2",
+                        flex="1",
+                    ),
+                    rx.text("", width="80px"),
+                    width="100%",
+                    spacing="2",
+                ),
+                spacing="2",
+                width="100%",
+            ),
+            max_width="600px",
+        ),
+        open=RunState.show_compare,
+        on_open_change=lambda open: rx.cond(
+            open,
+            RunState.open_compare(),
+            RunState.close_compare(),
+        ),
+    )
+
+
 @rx.page(route="/runs", title="Eval Runs", on_load=RunState.load_runs)
 def runs_page() -> rx.Component:
     return layout(
@@ -477,6 +661,16 @@ def runs_page() -> rx.Component:
             rx.hstack(
                 page_header("Eval Runs", "Configure and run evaluations"),
                 rx.spacer(),
+                rx.cond(
+                    RunState.compare_selected.length() == 2,
+                    rx.button(
+                        rx.icon("git-compare", size=16),
+                        "Compare (2)",
+                        on_click=RunState.open_compare,
+                        variant="soft",
+                        size="2",
+                    ),
+                ),
                 rx.button(
                     rx.icon("plus", size=16),
                     "New Run",
@@ -492,6 +686,7 @@ def runs_page() -> rx.Component:
                 empty_state("No eval runs yet. Create a dataset first, then start a run.", "play"),
             ),
             create_run_dialog(),
+            compare_dialog(),
             spacing="4",
             width="100%",
         ),

--- a/web/pages/runs.py
+++ b/web/pages/runs.py
@@ -49,7 +49,9 @@ class RunState(State):
     # Compare mode
     compare_selected: list[int] = []
     show_compare: bool = False
-    compare_data: dict = {}
+    compare_run_a: dict = {}
+    compare_run_b: dict = {}
+    compare_metrics: list[dict] = []
 
     def load_runs(self) -> None:
         with rx.session() as session:
@@ -168,27 +170,25 @@ class RunState(State):
         scores_b = avg_scores(results_b)
         all_metrics = sorted(set(scores_a) | set(scores_b))
 
-        self.compare_data = {
-            "run_a": {
-                "id": run_a.id,
-                "name": run_a.name,
-                "pass_rate": f"{pass_rate(results_a):.0%}",
-            },
-            "run_b": {
-                "id": run_b.id,
-                "name": run_b.name,
-                "pass_rate": f"{pass_rate(results_b):.0%}",
-            },
-            "metrics": [
-                {
-                    "name": m,
-                    "a_score": scores_a.get(m, 0),
-                    "b_score": scores_b.get(m, 0),
-                    "delta": scores_b.get(m, 0) - scores_a.get(m, 0),
-                }
-                for m in all_metrics
-            ],
+        self.compare_run_a = {
+            "name": run_a.name,
+            "pass_rate": f"{pass_rate(results_a):.0%}",
         }
+        self.compare_run_b = {
+            "name": run_b.name,
+            "pass_rate": f"{pass_rate(results_b):.0%}",
+        }
+        self.compare_metrics = [
+            {
+                "name": m,
+                "a_score": f"{scores_a.get(m, 0):.0%}",
+                "b_score": f"{scores_b.get(m, 0):.0%}",
+                "delta_up": scores_b.get(m, 0) > scores_a.get(m, 0),
+                "delta_down": scores_b.get(m, 0) < scores_a.get(m, 0),
+                "delta_display": f"{abs(scores_b.get(m, 0) - scores_a.get(m, 0)):.0%}",
+            }
+            for m in all_metrics
+        ]
 
     def open_compare(self) -> None:
         self.load_compare_data()
@@ -569,13 +569,13 @@ def compare_dialog() -> rx.Component:
                 rx.hstack(
                     rx.text("Metric", weight="medium", width="160px"),
                     rx.text(
-                        RunState.compare_data["run_a"]["name"],
+                        RunState.compare_run_a["name"],
                         weight="medium",
                         flex="1",
                         color_scheme="blue",
                     ),
                     rx.text(
-                        RunState.compare_data["run_b"]["name"],
+                        RunState.compare_run_b["name"],
                         weight="medium",
                         flex="1",
                         color_scheme="teal",
@@ -587,30 +587,22 @@ def compare_dialog() -> rx.Component:
                 rx.separator(width="100%"),
                 # Metric rows
                 rx.foreach(
-                    RunState.compare_data["metrics"],
+                    RunState.compare_metrics,
                     lambda m: rx.hstack(
-                        rx.text(m["name"].to(str), size="2", width="160px"),
-                        rx.text(
-                            (m["a_score"] * 100).to(int).to(str) + "%",
-                            size="2",
-                            flex="1",
-                        ),
-                        rx.text(
-                            (m["b_score"] * 100).to(int).to(str) + "%",
-                            size="2",
-                            flex="1",
-                        ),
+                        rx.text(m["name"], size="2", width="160px"),
+                        rx.text(m["a_score"], size="2", flex="1"),
+                        rx.text(m["b_score"], size="2", flex="1"),
                         rx.cond(
-                            m["delta"] > 0,
+                            m["delta_up"],
                             rx.badge(
-                                "↑ " + (m["delta"] * 100).to(int).to(str) + "%",
+                                "↑ " + m["delta_display"],
                                 color_scheme="green",
                                 size="1",
                             ),
                             rx.cond(
-                                m["delta"] < 0,
+                                m["delta_down"],
                                 rx.badge(
-                                    "↓ " + (m["delta"] * 100).to(int).to(str) + "%",
+                                    "↓ " + m["delta_display"],
                                     color_scheme="red",
                                     size="1",
                                 ),
@@ -626,16 +618,8 @@ def compare_dialog() -> rx.Component:
                 # Pass rate row
                 rx.hstack(
                     rx.text("Pass Rate", size="2", weight="medium", width="160px"),
-                    rx.text(
-                        RunState.compare_data["run_a"]["pass_rate"],
-                        size="2",
-                        flex="1",
-                    ),
-                    rx.text(
-                        RunState.compare_data["run_b"]["pass_rate"],
-                        size="2",
-                        flex="1",
-                    ),
+                    rx.text(RunState.compare_run_a["pass_rate"], size="2", flex="1"),
+                    rx.text(RunState.compare_run_b["pass_rate"], size="2", flex="1"),
                     rx.text("", width="80px"),
                     width="100%",
                     spacing="2",

--- a/web/pages/runs.py
+++ b/web/pages/runs.py
@@ -6,6 +6,7 @@ import time
 from datetime import datetime
 
 import reflex as rx
+from loguru import logger
 from sqlmodel import select
 
 from web.components import empty_state, layout, page_header, status_badge
@@ -361,6 +362,7 @@ class RunState(State):
                             session.commit()
 
                 except Exception as e:
+                    logger.error(f"Case {idx} failed: {e}")
                     async with self:
                         with rx.session() as session:
                             result = EvalResult(

--- a/web/pages/settings.py
+++ b/web/pages/settings.py
@@ -1,6 +1,7 @@
 """Settings page — config display, connection test, test agent, app registration guide."""
 
 import os
+import re
 from pathlib import Path
 
 import reflex as rx
@@ -14,6 +15,8 @@ ENV_VARS = [
     ("AZURE_AD_CLIENT_SECRET", "Azure AD Client Secret"),
     ("COPILOT_ENVIRONMENT_ID", "Copilot Environment ID"),
     ("COPILOT_AGENT_IDENTIFIER", "Copilot Agent Identifier"),
+    ("COPILOT_AGENT_SCHEMA", "Copilot Agent Schema Name"),
+    ("DATAVERSE_ORG_URL", "Dataverse Org URL"),
     ("AZURE_OPENAI_ENDPOINT", "Azure OpenAI Endpoint"),
     ("AZURE_OPENAI_API_KEY", "Azure OpenAI API Key"),
     ("AZURE_OPENAI_DEPLOYMENT_NAME", "Azure OpenAI Deployment"),
@@ -24,6 +27,12 @@ SECRET_VARS = {"AZURE_AD_CLIENT_SECRET", "AZURE_OPENAI_API_KEY"}
 
 # Build a flat list of var names for indexing
 VAR_NAMES = [v[0] for v in ENV_VARS]
+
+
+_UUID_RE = re.compile(
+    r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+    re.IGNORECASE,
+)
 
 
 def _find_env_file() -> Path:
@@ -45,6 +54,7 @@ class SettingsState(State):
     test_agent_response: str = ""
     is_testing_agent: bool = False
     guide_open: bool = False
+    d2e_url: str = ""
 
     # Edit mode
     edit_mode: bool = False
@@ -52,10 +62,25 @@ class SettingsState(State):
     save_result: str = ""
     save_success: bool = False
 
+    test_agent_403: bool = False
+    client_id_display: str = ""
+
+    # GUID resolve
+    agent_id_is_guid: bool = False
+    resolved_schema_name: str = ""
+    schema_resolve_error: str = ""
+    is_resolving_schema: bool = False
+    manual_schema_name: str = ""
+
     def set_test_agent_message(self, value: str) -> None:
         self.test_agent_message = value
 
+    def set_manual_schema_name(self, value: str) -> None:
+        self.manual_schema_name = value
+
     def load_config(self) -> None:
+        from dotenv import load_dotenv
+        load_dotenv(override=True)
         items = []
         for var_name, label in ENV_VARS:
             value = os.getenv(var_name, "")
@@ -67,6 +92,22 @@ class SettingsState(State):
                 display = value
             items.append([label, display, "set" if value else "missing"])
         self.config_items = items
+
+        agent_id = os.getenv("COPILOT_AGENT_IDENTIFIER", "")
+        schema_set = bool(os.getenv("COPILOT_AGENT_SCHEMA", "").strip())
+        self.agent_id_is_guid = bool(_UUID_RE.match(agent_id)) and not schema_set
+        self.resolved_schema_name = ""
+        self.schema_resolve_error = ""
+        self.manual_schema_name = ""
+        self.client_id_display = os.getenv("AZURE_AD_CLIENT_ID", "(not set)")
+
+        try:
+            from d2e_client import _get_settings
+            settings = _get_settings()
+            from microsoft_agents.copilotstudio.client.power_platform_environment import PowerPlatformEnvironment
+            self.d2e_url = PowerPlatformEnvironment.get_copilot_studio_connection_url(settings=settings)
+        except Exception:
+            self.d2e_url = ""
 
     def toggle_edit_mode(self) -> None:
         if not self.edit_mode:
@@ -124,6 +165,96 @@ class SettingsState(State):
             self.save_success = False
             self.save_result = f"Error saving: {e}"
 
+    def resolve_schema_name(self) -> None:
+        """Look up the agent schema name from Dataverse using the GUID in COPILOT_AGENT_IDENTIFIER."""
+        from dotenv import load_dotenv
+        load_dotenv(override=True)
+
+        client_secret = os.getenv("AZURE_AD_CLIENT_SECRET", "")
+        if not client_secret:
+            self.schema_resolve_error = "AZURE_AD_CLIENT_SECRET is required for auto-resolve."
+            return
+
+        self.is_resolving_schema = True
+        self.resolved_schema_name = ""
+        self.schema_resolve_error = ""
+        yield
+
+        try:
+            import httpx
+            import msal
+
+            tenant_id = os.environ["AZURE_AD_TENANT_ID"]
+            client_id = os.environ["AZURE_AD_CLIENT_ID"]
+            org_url = os.environ["DATAVERSE_ORG_URL"].rstrip("/")
+            agent_id = os.environ["COPILOT_AGENT_IDENTIFIER"]
+
+            app = msal.ConfidentialClientApplication(
+                client_id,
+                authority=f"https://login.microsoftonline.com/{tenant_id}",
+                client_credential=client_secret,
+            )
+            result = app.acquire_token_for_client(scopes=[f"{org_url}/.default"])
+            if "access_token" not in result:
+                error = result.get("error_description", result.get("error", "Unknown"))
+                self.schema_resolve_error = f"Token acquisition failed: {error}"
+                return
+
+            resp = httpx.get(
+                f"{org_url}/api/data/v9.2/bots({agent_id})",
+                params={"$select": "schemaname,name"},
+                headers={"Authorization": f"Bearer {result['access_token']}"},
+                timeout=30,
+            )
+            if resp.status_code >= 400:
+                self.schema_resolve_error = f"Dataverse query failed: {resp.status_code} {resp.text[:200]}"
+                return
+
+            bot_data = resp.json()
+            schema_name = bot_data.get("schemaname", "")
+            if not schema_name:
+                self.schema_resolve_error = "Bot found but has no schemaname field."
+                return
+
+            self.resolved_schema_name = schema_name
+        except Exception as e:
+            self.schema_resolve_error = f"Error: {e}"
+        finally:
+            self.is_resolving_schema = False
+
+    def save_schema_name(self) -> None:
+        """Write schema name (resolved or manual) as COPILOT_AGENT_SCHEMA to .env and reload."""
+        schema_name = self.resolved_schema_name or self.manual_schema_name
+        if not schema_name:
+            return
+        env_path = _find_env_file()
+        try:
+            existing_lines: list[str] = []
+            if env_path.exists():
+                existing_lines = env_path.read_text().splitlines()
+
+            existing_map: dict[str, int] = {}
+            for idx, line in enumerate(existing_lines):
+                stripped = line.strip()
+                if stripped and not stripped.startswith("#") and "=" in stripped:
+                    key = stripped.split("=", 1)[0].strip()
+                    existing_map[key] = idx
+
+            new_line = f"COPILOT_AGENT_SCHEMA={schema_name}"
+            if "COPILOT_AGENT_SCHEMA" in existing_map:
+                existing_lines[existing_map["COPILOT_AGENT_SCHEMA"]] = new_line
+            else:
+                existing_lines.append(new_line)
+
+            env_path.write_text("\n".join(existing_lines) + "\n")
+
+            from dotenv import load_dotenv
+            load_dotenv(str(env_path), override=True)
+
+            self.load_config()
+        except Exception as e:
+            self.schema_resolve_error = f"Error saving: {e}"
+
     def test_connection(self) -> None:
         from dotenv import load_dotenv
         load_dotenv(override=True)
@@ -151,12 +282,15 @@ class SettingsState(State):
 
         self.is_testing_agent = True
         self.test_agent_response = ""
+        self.test_agent_403 = False
         yield
         try:
             from d2e_client import test_agent
             self.test_agent_response = test_agent(self.test_agent_message)
         except Exception as e:
-            self.test_agent_response = f"Error: {e}"
+            msg = str(e)
+            self.test_agent_403 = "HTTP 403" in msg
+            self.test_agent_response = f"Error: {msg}"
         finally:
             self.is_testing_agent = False
 
@@ -224,6 +358,109 @@ def _edit_field(index: int, var_name: str, label: str) -> rx.Component:
         ),
         spacing="4",
         align="center",
+        width="100%",
+    )
+
+
+def _guid_warning_banner() -> rx.Component:
+    return rx.vstack(
+        rx.callout(
+            rx.hstack(
+                rx.text(
+                    "COPILOT_AGENT_IDENTIFIER is a GUID. D2E requires the schema name (e.g. cr123_myagent).",
+                    size="2",
+                ),
+                rx.spacer(),
+                rx.button(
+                    rx.cond(
+                        SettingsState.is_resolving_schema,
+                        rx.hstack(rx.spinner(size="1"), rx.text("Resolving..."), align="center", spacing="2"),
+                        rx.text("Resolve from Dataverse"),
+                    ),
+                    on_click=SettingsState.resolve_schema_name,
+                    disabled=SettingsState.is_resolving_schema,
+                    size="2",
+                    color_scheme="amber",
+                    variant="soft",
+                ),
+                align="center",
+                width="100%",
+            ),
+            icon="triangle_alert",
+            color_scheme="amber",
+            width="100%",
+        ),
+        rx.cond(
+            SettingsState.schema_resolve_error != "",
+            rx.vstack(
+                rx.callout(
+                    rx.vstack(
+                        rx.text(SettingsState.schema_resolve_error, size="2"),
+                        rx.text(
+                            "The app service principal needs to be added as an Application User in Dataverse "
+                            "(Power Platform Admin Center → Environments → Users → Application Users). "
+                            "Or enter the schema name manually below.",
+                            size="2",
+                            color="var(--red-11)",
+                        ),
+                        spacing="1",
+                        width="100%",
+                    ),
+                    icon="triangle_alert",
+                    color_scheme="red",
+                    width="100%",
+                ),
+                rx.hstack(
+                    rx.input(
+                        placeholder="e.g. cr123_myagent",
+                        value=SettingsState.manual_schema_name,
+                        on_change=SettingsState.set_manual_schema_name,
+                        font_family="var(--font-mono)",
+                        size="2",
+                        width="100%",
+                    ),
+                    rx.button(
+                        rx.icon("save", size=14),
+                        "Save to .env",
+                        on_click=SettingsState.save_schema_name,
+                        disabled=SettingsState.manual_schema_name == "",
+                        size="2",
+                        color_scheme="green",
+                    ),
+                    align="center",
+                    spacing="2",
+                    width="100%",
+                ),
+                spacing="2",
+                width="100%",
+            ),
+        ),
+        rx.cond(
+            SettingsState.resolved_schema_name != "",
+            rx.callout(
+                rx.hstack(
+                    rx.vstack(
+                        rx.text("Schema name resolved:", size="1", weight="medium", color="var(--gray-a8)"),
+                        rx.code(SettingsState.resolved_schema_name, size="2"),
+                        spacing="1",
+                    ),
+                    rx.spacer(),
+                    rx.button(
+                        rx.icon("save", size=14),
+                        "Save to .env",
+                        on_click=SettingsState.save_schema_name,
+                        size="2",
+                        color_scheme="green",
+                    ),
+                    align="center",
+                    width="100%",
+                ),
+                icon="check",
+                color_scheme="green",
+                width="100%",
+            ),
+        ),
+        spacing="2",
         width="100%",
     )
 
@@ -302,6 +539,10 @@ def config_section() -> rx.Component:
                 ),
                 # Read-only table
                 _config_view_table(),
+            ),
+            rx.cond(
+                SettingsState.agent_id_is_guid,
+                _guid_warning_banner(),
             ),
             spacing="4",
             width="100%",
@@ -393,6 +634,15 @@ def test_agent_section() -> rx.Component:
                 align="start",
                 width="100%",
             ),
+            rx.cond(
+                SettingsState.d2e_url != "",
+                rx.vstack(
+                    rx.text("D2E endpoint", size="1", weight="medium", color="var(--gray-a8)"),
+                    rx.code(SettingsState.d2e_url, size="1"),
+                    spacing="1",
+                    width="100%",
+                ),
+            ),
             rx.hstack(
                 rx.input(
                     placeholder="Type a test message...",
@@ -438,6 +688,37 @@ def test_agent_section() -> rx.Component:
                         width="100%",
                     ),
                     spacing="2",
+                    width="100%",
+                ),
+            ),
+            rx.cond(
+                SettingsState.test_agent_403,
+                rx.callout(
+                    rx.vstack(
+                        rx.text(
+                            "403 — D2E rejected the request. Two likely causes:",
+                            size="2",
+                            weight="bold",
+                        ),
+                        rx.text(
+                            "1. Stale token: the cached browser-login token expired. "
+                            "Delete .local_token_cache.json and restart the app to force a fresh login.",
+                            size="2",
+                        ),
+                        rx.text(
+                            "2. Wrong agent identifier: if COPILOT_AGENT_SCHEMA is set in .env, "
+                            "verify it matches the exact schema name of your agent (e.g. cr123_myagent).",
+                            size="2",
+                        ),
+                        rx.code(
+                            "Client ID: " + SettingsState.client_id_display,
+                            size="1",
+                        ),
+                        spacing="2",
+                        width="100%",
+                    ),
+                    icon="triangle_alert",
+                    color_scheme="red",
                     width="100%",
                 ),
             ),

--- a/web/pages/setup.py
+++ b/web/pages/setup.py
@@ -1,4 +1,6 @@
-"""Setup page — automated Azure AD app registration from Copilot Studio agent URL."""
+"""Setup page — fill environment variables from Copilot Studio agent URL."""
+
+import os
 
 import reflex as rx
 
@@ -13,33 +15,34 @@ class SetupState(State):
     agent_url: str = ""
     url_error: str = ""
 
-    # Step 2
+    # Parsed from URL
     environment_id: str = ""
     bot_id: str = ""
-    agent_identifier: str = ""
-    app_display_name: str = "Copilot Studio Eval Platform"
 
-    # Step 3
+    # Step 2 — existing app registration
+    client_id: str = ""
+    agent_identifier: str = ""  # optional; auto-detect from Dataverse if empty
+
+    # Step 3 — provisioning
     is_provisioning: bool = False
     provisioning_error: str = ""
     device_code: str = ""
     device_code_url: str = ""
     log_lines: list[str] = []
 
-    # Step 4
-    created_tenant_id: str = ""
-    created_client_id: str = ""
-    created_client_secret: str = ""
-    env_written: bool = False
+    # Step 4 — result
+    written_tenant_id: str = ""
+    written_org_url: str = ""
+    written_agent_id: str = ""
 
     def set_agent_url(self, value: str) -> None:
         self.agent_url = value
 
+    def set_client_id(self, value: str) -> None:
+        self.client_id = value
+
     def set_agent_identifier(self, value: str) -> None:
         self.agent_identifier = value
-
-    def set_app_display_name(self, value: str) -> None:
-        self.app_display_name = value
 
     def parse_url(self) -> None:
         self.url_error = ""
@@ -49,10 +52,16 @@ class SetupState(State):
             parsed = parse_copilot_url(self.agent_url)
             self.environment_id = parsed.environment_id
             self.bot_id = parsed.bot_id
-            self.agent_identifier = ""
+            self.client_id = os.getenv("AZURE_AD_CLIENT_ID", "")
+            # Use the bot GUID directly — no schema name lookup needed
+            self.agent_identifier = parsed.bot_id
             self.current_step = 2
         except ValueError as e:
             self.url_error = str(e)
+
+    def go_back(self) -> None:
+        if self.current_step > 1:
+            self.current_step -= 1
 
     @rx.event(background=True)
     async def provision(self) -> None:
@@ -63,10 +72,10 @@ class SetupState(State):
             self.device_code = ""
             self.device_code_url = ""
             self.log_lines = []
-            display_name = self.app_display_name
             env_id = self.environment_id
-            bot_guid = self.bot_id
-            agent_id = self.agent_identifier
+            bot_id = self.bot_id
+            app_client_id = self.client_id.strip()
+            agent_id = self.agent_identifier.strip()
 
         async def _log(msg: str) -> None:
             async with self:
@@ -76,14 +85,18 @@ class SetupState(State):
             import webbrowser
 
             from provisioner import (
+                add_secret_to_existing_app,
                 complete_device_flow,
-                create_app_registration,
                 initiate_device_flow,
                 lookup_agent_schema_name,
-                register_power_platform_admin_app,
+                lookup_dataverse_org_url,
                 update_env_file,
             )
 
+            if not app_client_id:
+                raise ValueError("Client ID is required")
+
+            # Step 1: device flow for Graph (uses Azure CLI public client — no secret needed)
             await _log("Initiating device code flow for Microsoft Graph...")
             msal_app, flow = initiate_device_flow()
 
@@ -95,106 +108,49 @@ class SetupState(State):
             webbrowser.open(flow["verification_uri"])
 
             await _log("Waiting for sign-in...")
-            token, tenant_id = complete_device_flow(msal_app, flow)
+            graph_token, tenant_id = complete_device_flow(msal_app, flow)
             await _log(f"Authenticated — tenant: {tenant_id}")
 
             async with self:
                 self.device_code = ""
 
-            await _log("Ensuring Power Platform API service principal exists...")
-            await _log("Creating app registration...")
-            result = create_app_registration(token, display_name)
-            await _log(f"App created — client ID: {result.client_id}")
+            # Step 2: add a new client secret to the existing app registration
+            await _log(f"Adding client secret to app {app_client_id}...")
+            client_secret = add_secret_to_existing_app(graph_token, app_client_id)
+            await _log("Client secret created.")
 
-            await _log("Registering as Power Platform admin application...")
+            # Step 3: BAP API → Dataverse org URL (uses cached BAP token, no second login)
+            await _log("Looking up Dataverse org URL...")
+            org_url = lookup_dataverse_org_url(msal_app, env_id)
+            await _log(f"Dataverse org URL: {org_url}")
 
-            def _on_bap_device_code(code: str, url: str) -> None:
-                # Can't use async here — this runs in a sync context inside
-                # register_power_platform_admin_app. We store the values and
-                # the UI will pick them up via the state vars set below.
-                pass
-
-            # We need to update UI with BAP device code if needed.
-            # Since the callback is sync, we pre-set a flag and use a wrapper.
-            bap_code_info: list[tuple[str, str]] = []
-
-            def _capture_bap_code(code: str, url: str) -> None:
-                bap_code_info.append((code, url))
-
-            # Try silent first, if it fails the callback captures the code
-            # We need to handle the async state update between the callback
-            # and the blocking device flow. Split into two phases:
-            from provisioner import _BAP_SCOPES
-
-            accounts = msal_app.get_accounts()
-            silent = msal_app.acquire_token_silent(_BAP_SCOPES, account=accounts[0])
-            if silent and "access_token" in silent:
-                await _log("BAP token acquired silently (cached)")
-                register_power_platform_admin_app(msal_app, result.client_id)
-            else:
-                await _log("Second sign-in required for Power Platform API...")
-                bap_flow = msal_app.initiate_device_flow(scopes=_BAP_SCOPES)
-                if "user_code" not in bap_flow:
-                    raise RuntimeError(f"BAP device flow failed: {bap_flow}")
-
-                async with self:
-                    self.device_code = bap_flow["user_code"]
-                    self.device_code_url = bap_flow["verification_uri"]
-
-                await _log(
-                    f"Sign in at {bap_flow['verification_uri']} "
-                    f"with code: {bap_flow['user_code']}"
-                )
-                webbrowser.open(bap_flow["verification_uri"])
-
-                await _log("Waiting for Power Platform sign-in...")
-                bap_result = msal_app.acquire_token_by_device_flow(bap_flow)
-                if "access_token" not in bap_result:
-                    error = bap_result.get("error_description", "Unknown")
-                    raise RuntimeError(f"BAP token failed: {error}")
-
-                async with self:
-                    self.device_code = ""
-
-                await _log("BAP token acquired")
-                # Now call register with the token already cached
-                register_power_platform_admin_app(msal_app, result.client_id)
-
-            await _log("Registered as Power Platform admin app")
-
-            # Look up agent schema name if not manually provided
+            # Step 4: look up agent schema name if not provided
             if not agent_id:
                 await _log("Looking up agent schema name from Dataverse...")
-                agent_id = lookup_agent_schema_name(msal_app, env_id, bot_guid)
+                agent_id = lookup_agent_schema_name(msal_app, env_id, bot_id)
                 await _log(f"Agent schema name: {agent_id}")
-                async with self:
-                    self.agent_identifier = agent_id
 
+            # Step 5: write all vars to .env and reload
             updates = {
-                "AZURE_AD_TENANT_ID": result.tenant_id,
-                "AZURE_AD_CLIENT_ID": result.client_id,
-                "AZURE_AD_CLIENT_SECRET": "",  # clear — D2E uses interactive auth
+                "AZURE_AD_TENANT_ID": tenant_id,
+                "AZURE_AD_CLIENT_ID": app_client_id,
+                "AZURE_AD_CLIENT_SECRET": client_secret,
                 "COPILOT_ENVIRONMENT_ID": env_id,
                 "COPILOT_AGENT_IDENTIFIER": agent_id,
+                "DATAVERSE_ORG_URL": org_url,
             }
 
             await _log("Writing .env file...")
             update_env_file(".env", updates)
 
             from dotenv import load_dotenv
-
             load_dotenv(override=True)
-            await _log("Done! .env updated and reloaded into running process.")
+            await _log("Done.")
 
             async with self:
-                self.created_tenant_id = result.tenant_id
-                self.created_client_id = result.client_id
-                secret = result.client_secret
-                if len(secret) > 8:
-                    self.created_client_secret = secret[:4] + "..." + secret[-4:]
-                else:
-                    self.created_client_secret = "****"
-                self.env_written = True
+                self.written_tenant_id = tenant_id
+                self.written_org_url = org_url
+                self.written_agent_id = agent_id
                 self.is_provisioning = False
                 self.current_step = 4
 
@@ -204,12 +160,10 @@ class SetupState(State):
                 self.provisioning_error = str(e)
                 self.is_provisioning = False
 
-    def go_back(self) -> None:
-        if self.current_step > 1:
-            self.current_step -= 1
 
-    def go_to_step(self, step: int) -> None:
-        self.current_step = step
+# ---------------------------------------------------------------------------
+# UI
+# ---------------------------------------------------------------------------
 
 
 def _step_indicator() -> rx.Component:
@@ -257,7 +211,7 @@ def _step_1_paste_url() -> rx.Component:
             rx.text(
                 "Open your agent in Copilot Studio and copy the URL from your browser.",
                 size="2",
-                color_scheme="gray",
+                color="var(--gray-a8)",
             ),
             rx.code(
                 "https://copilotstudio.preview.microsoft.com"
@@ -280,11 +234,7 @@ def _step_1_paste_url() -> rx.Component:
                     width="100%",
                 ),
             ),
-            rx.button(
-                "Parse URL",
-                on_click=SetupState.parse_url,
-                size="3",
-            ),
+            rx.button("Next", on_click=SetupState.parse_url, size="3"),
             spacing="3",
             width="100%",
         ),
@@ -296,15 +246,16 @@ def _step_2_confirm() -> rx.Component:
     return rx.card(
         rx.vstack(
             rx.text(
-                "Confirm configuration",
+                "Confirm your existing app registration",
                 size="3",
                 weight="bold",
                 letter_spacing="-0.01em",
             ),
             rx.text(
-                "Review the extracted values before creating the app registration.",
+                "A browser window will open for Microsoft login. "
+                "A new client secret will be generated and added to your existing app registration.",
                 size="2",
-                color_scheme="gray",
+                color="var(--gray-a8)",
             ),
             rx.vstack(
                 rx.text("Environment ID", size="2", weight="medium"),
@@ -317,34 +268,39 @@ def _step_2_confirm() -> rx.Component:
                 spacing="1",
             ),
             rx.vstack(
-                rx.text("Agent Identifier (schema name)", size="2", weight="medium"),
+                rx.text("Application (client) ID", size="2", weight="medium"),
                 rx.text(
-                    "Leave empty to auto-detect from Dataverse, or enter manually "
-                    "(e.g. cr123_myAgent).",
+                    "Azure Portal → App registrations → your app → Overview → Application (client) ID.",
                     size="1",
-                    color_scheme="gray",
+                    color="var(--gray-a8)",
                 ),
                 rx.input(
-                    placeholder="auto-detect if empty",
-                    value=SetupState.agent_identifier,
-                    on_change=SetupState.set_agent_identifier,
+                    placeholder="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+                    value=SetupState.client_id,
+                    on_change=SetupState.set_client_id,
                     width="100%",
+                    font_family="var(--font-mono)",
                 ),
                 spacing="1",
             ),
             rx.vstack(
-                rx.text("App Display Name", size="2", weight="medium"),
+                rx.text("Agent Identifier (bot UUID)", size="2", weight="medium"),
+                rx.text(
+                    "Pre-filled from the URL. Override only if you want to use a schema name instead.",
+                    size="1",
+                    color="var(--gray-a8)",
+                ),
                 rx.input(
-                    value=SetupState.app_display_name,
-                    on_change=SetupState.set_app_display_name,
+                    placeholder="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+                    value=SetupState.agent_identifier,
+                    on_change=SetupState.set_agent_identifier,
                     width="100%",
+                    font_family="var(--font-mono)",
                 ),
                 spacing="1",
             ),
             rx.callout(
-                "This will open your browser for Azure AD login (possibly twice: "
-                "once for Graph API, once for Power Platform). "
-                "You need admin permissions in your tenant.",
+                "You need Application.ReadWrite.All in your tenant to add secrets to the app registration.",
                 icon="info",
                 color_scheme="blue",
                 width="100%",
@@ -357,7 +313,7 @@ def _step_2_confirm() -> rx.Component:
                     size="3",
                 ),
                 rx.button(
-                    "Create App Registration",
+                    "Login & Configure",
                     on_click=SetupState.provision,
                     size="3",
                 ),
@@ -374,7 +330,7 @@ def _step_3_provisioning() -> rx.Component:
     return rx.card(
         rx.vstack(
             rx.text(
-                "Creating app registration",
+                "Configuring environment",
                 size="3",
                 weight="bold",
                 letter_spacing="-0.01em",
@@ -411,7 +367,7 @@ def _step_3_provisioning() -> rx.Component:
                 SetupState.is_provisioning,
                 rx.hstack(
                     rx.spinner(size="3"),
-                    rx.text("Provisioning in progress...", size="2", color_scheme="gray"),
+                    rx.text("Working...", size="2", color="var(--gray-a8)"),
                     spacing="3",
                     align="center",
                 ),
@@ -458,7 +414,7 @@ def _step_4_done() -> rx.Component:
     return rx.card(
         rx.vstack(
             rx.callout(
-                "App registration created and .env updated successfully!",
+                ".env updated and reloaded successfully.",
                 icon="check",
                 color_scheme="green",
                 width="100%",
@@ -466,36 +422,40 @@ def _step_4_done() -> rx.Component:
             rx.table.root(
                 rx.table.header(
                     rx.table.row(
-                        rx.table.column_header_cell("Setting"),
+                        rx.table.column_header_cell("Variable"),
                         rx.table.column_header_cell("Value"),
                     ),
                 ),
                 rx.table.body(
                     rx.table.row(
-                        rx.table.cell(rx.text("Tenant ID", weight="medium")),
-                        rx.table.cell(rx.code(SetupState.created_tenant_id)),
+                        rx.table.cell(rx.text("AZURE_AD_TENANT_ID", weight="medium")),
+                        rx.table.cell(rx.code(SetupState.written_tenant_id)),
                     ),
                     rx.table.row(
-                        rx.table.cell(rx.text("Client ID", weight="medium")),
-                        rx.table.cell(rx.code(SetupState.created_client_id)),
+                        rx.table.cell(rx.text("DATAVERSE_ORG_URL", weight="medium")),
+                        rx.table.cell(rx.code(SetupState.written_org_url)),
                     ),
                     rx.table.row(
-                        rx.table.cell(rx.text("Client Secret", weight="medium")),
-                        rx.table.cell(rx.code(SetupState.created_client_secret)),
+                        rx.table.cell(rx.text("COPILOT_AGENT_IDENTIFIER", weight="medium")),
+                        rx.table.cell(rx.code(SetupState.written_agent_id)),
+                    ),
+                    rx.table.row(
+                        rx.table.cell(rx.text("AZURE_AD_CLIENT_SECRET", weight="medium")),
+                        rx.table.cell(rx.text("written to .env", color="var(--gray-a8)", size="2")),
                     ),
                 ),
                 width="100%",
             ),
-            rx.callout(
-                "The client secret is NOT written to .env — D2E uses interactive auth. "
-                "Save the secret above if you need it for CI/headless runs later.",
-                icon="info",
-                color_scheme="orange",
-                width="100%",
-            ),
-            rx.link(
-                rx.button("Go to Settings", size="3", variant="outline"),
-                href="/settings",
+            rx.hstack(
+                rx.link(
+                    rx.button("Go to Transcript Extract", size="3"),
+                    href="/retro",
+                ),
+                rx.link(
+                    rx.button("Settings", size="3", variant="outline"),
+                    href="/settings",
+                ),
+                spacing="3",
             ),
             spacing="4",
             width="100%",
@@ -508,7 +468,10 @@ def _step_4_done() -> rx.Component:
 def setup_page() -> rx.Component:
     return layout(
         rx.vstack(
-            page_header("Setup", "Automated Azure AD app registration from your agent URL"),
+            page_header(
+                "Setup",
+                "Configure environment variables from your Copilot Studio agent URL",
+            ),
             _step_indicator(),
             rx.cond(SetupState.current_step == 1, _step_1_paste_url()),
             rx.cond(SetupState.current_step == 2, _step_2_confirm()),

--- a/web/web.py
+++ b/web/web.py
@@ -6,6 +6,9 @@ from web.pages.dashboard import dashboard_page  # noqa: F401
 from web.pages.dataset_detail import dataset_detail_page  # noqa: F401
 from web.pages.datasets import datasets_page  # noqa: F401
 from web.pages.run_detail import run_detail_page  # noqa: F401
+from web.pages.retro import retro_page  # noqa: F401
+from web.pages.retro_suggest import retro_suggest_page  # noqa: F401
+from web.pages.retro_conversations import retro_conversations_page  # noqa: F401
 from web.pages.runs import runs_page  # noqa: F401
 from web.pages.settings import settings_page  # noqa: F401
 from web.pages.setup import setup_page  # noqa: F401


### PR DESCRIPTION
## Summary
- Add Transcript Extract page (`/retro`) with device flow auth for Dataverse — always uses user-delegated token to avoid 403 with client credentials
- Add conversation viewer and dataset suggestion sub-pages
- Extend DataverseClient, D2EClient, and retro eval runner with topic routing and CSAT scoring
- Update sidebar nav, run detail, runs list, settings, and setup pages

## Test Plan
- [ ] Navigate to `/retro`, click "Transcript Extract" — device code appears
- [ ] Complete browser login, transcripts are fetched without 403
- [ ] New run appears in "Recent Runs" with `completed` status
- [ ] All 92 tests pass: `uv run pytest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)